### PR TITLE
chore: initialize backend

### DIFF
--- a/backend/SmartCare/src/main/java/com/iot/smartcare/SmartCareApplication.java
+++ b/backend/SmartCare/src/main/java/com/iot/smartcare/SmartCareApplication.java
@@ -1,0 +1,13 @@
+package com.iot.smartcare;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class SmartCareApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(SmartCareApplication.class, args);
+    }
+
+}

--- a/backend/SmartCare/src/main/java/com/iot/smartcare/controller/HealthCheckController.java
+++ b/backend/SmartCare/src/main/java/com/iot/smartcare/controller/HealthCheckController.java
@@ -1,0 +1,4 @@
+package com.iot.smartcare.controller;
+
+public class HealthCheckController {
+}

--- a/backend/src/main/java/com/iothealth/backend/BackendApplication.java
+++ b/backend/src/main/java/com/iothealth/backend/BackendApplication.java
@@ -1,0 +1,13 @@
+package com.iothealth.backend;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class BackendApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(BackendApplication.class, args);
+	}
+
+}

--- a/backend/src/main/java/com/iothealth/backend/controller/HealthCheckController.java
+++ b/backend/src/main/java/com/iothealth/backend/controller/HealthCheckController.java
@@ -1,0 +1,20 @@
+package com.iothealth.backend.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.Instant;
+import java.util.Map;
+
+@RestController
+public class HealthCheckController {
+
+    @GetMapping("/api/v1/health-check")
+    public Map<String, Object> healthCheck() {
+        return Map.of(
+                "status", "UP",
+                "service", "iot-health-backend",
+                "timestamp", Instant.now()
+        );
+    }
+}

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -1,0 +1,25 @@
+spring:
+  application:
+    name: iot-health-backend
+
+  datasource:
+    url: jdbc:postgresql://localhost:5432/iot_health_db
+    username: postgres
+    password: 1234
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+
+server:
+  port: 8080
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info


### PR DESCRIPTION
## Summary by Sourcery

Initialize the Spring Boot backend service and add a basic health-check API endpoint.

New Features:
- Introduce a Spring Boot backend application entry point for the iot-health-backend service.
- Add a REST health-check endpoint exposing basic service status and metadata.

Enhancements:
- Configure Spring Boot application properties including datasource, JPA, server port, and actuator health/info exposure.
- Add an initial SmartCare Spring Boot module and placeholder controller for future development.