### PR TITLE
feat: implement patient service and controller

### DIFF
--- a/backend/src/main/java/com/iothealth/backend/controller/PatientController.java
+++ b/backend/src/main/java/com/iothealth/backend/controller/PatientController.java
@@ -1,0 +1,49 @@
+package com.iothealth.backend.controller;
+
+import com.iothealth.backend.dto.patient.PatientRequest;
+import com.iothealth.backend.dto.patient.PatientResponse;
+import com.iothealth.backend.service.PatientService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/patients")
+@RequiredArgsConstructor
+public class PatientController {
+
+    private final PatientService patientService;
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public PatientResponse createPatient(@Valid @RequestBody PatientRequest request) {
+        return patientService.createPatient(request);
+    }
+
+    @GetMapping
+    public List<PatientResponse> getAllPatients() {
+        return patientService.getAllPatients();
+    }
+
+    @GetMapping("/{id}")
+    public PatientResponse getPatientById(@PathVariable Long id) {
+        return patientService.getPatientById(id);
+    }
+
+    @PutMapping("/{id}")
+    public PatientResponse updatePatient(
+            @PathVariable Long id,
+            @Valid @RequestBody PatientRequest request
+    ) {
+        return patientService.updatePatient(id, request);
+    }
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deletePatient(@PathVariable Long id) {
+        patientService.deletePatient(id);
+    }
+}

--- a/backend/src/main/java/com/iothealth/backend/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/iothealth/backend/exception/GlobalExceptionHandler.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.dao.DataIntegrityViolationException;
 
 import java.time.Instant;
 import java.util.HashMap;
@@ -107,5 +108,22 @@ public class GlobalExceptionHandler {
         );
 
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
+    }
+
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<ErrorResponse> handleDataIntegrityViolationException(
+            DataIntegrityViolationException exception,
+            HttpServletRequest request
+    ) {
+        ErrorResponse response = new ErrorResponse(
+                Instant.now(),
+                HttpStatus.BAD_REQUEST.value(),
+                HttpStatus.BAD_REQUEST.getReasonPhrase(),
+                "Database constraint violation. The provided data conflicts with existing records.",
+                request.getRequestURI(),
+                null
+        );
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
     }
 }

--- a/backend/src/main/java/com/iothealth/backend/service/PatientService.java
+++ b/backend/src/main/java/com/iothealth/backend/service/PatientService.java
@@ -1,0 +1,75 @@
+package com.iothealth.backend.service;
+
+import com.iothealth.backend.dto.patient.PatientRequest;
+import com.iothealth.backend.dto.patient.PatientResponse;
+import com.iothealth.backend.entity.Patient;
+import com.iothealth.backend.exception.BadRequestException;
+import com.iothealth.backend.exception.ResourceNotFoundException;
+import com.iothealth.backend.mapper.PatientMapper;
+import com.iothealth.backend.repository.PatientRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PatientService {
+
+    private final PatientRepository patientRepository;
+
+    public PatientResponse createPatient(PatientRequest request) {
+        validateRoomNumberIsUnique(request.roomNumber());
+
+        Patient patient = PatientMapper.toEntity(request);
+        Patient savedPatient = patientRepository.save(patient);
+
+        return PatientMapper.toResponse(savedPatient);
+    }
+
+    @Transactional(readOnly = true)
+    public List<PatientResponse> getAllPatients() {
+        return patientRepository.findAll()
+                .stream()
+                .map(PatientMapper::toResponse)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public PatientResponse getPatientById(Long id) {
+        Patient patient = findPatientEntityById(id);
+        return PatientMapper.toResponse(patient);
+    }
+
+    public PatientResponse updatePatient(Long id, PatientRequest request) {
+        Patient existingPatient = findPatientEntityById(id);
+
+        if (!existingPatient.getRoomNumber().equals(request.roomNumber())) {
+            validateRoomNumberIsUnique(request.roomNumber());
+        }
+
+        PatientMapper.updateEntity(existingPatient, request);
+        Patient updatedPatient = patientRepository.save(existingPatient);
+
+        return PatientMapper.toResponse(updatedPatient);
+    }
+
+    public void deletePatient(Long id) {
+        Patient patient = findPatientEntityById(id);
+        patientRepository.delete(patient);
+    }
+
+    @Transactional(readOnly = true)
+    public Patient findPatientEntityById(Long id) {
+        return patientRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Patient not found with id: " + id));
+    }
+
+    private void validateRoomNumberIsUnique(String roomNumber) {
+        if (patientRepository.existsByRoomNumber(roomNumber)) {
+            throw new BadRequestException("Room number already assigned: " + roomNumber);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Implements the Patient service and REST controller.

## Related Issue
Closes #26 

## Changes
- Added PatientService with CRUD operations
- Added PatientController with REST endpoints
- Added room number uniqueness validation
- Integrated global exception handling for not found and bad request cases

## Testing
- [ ] Ran `./mvnw clean test`
- [ ] Tested patient creation
- [ ] Tested patient listing
- [ ] Tested patient lookup by ID
- [ ] Tested patient update
- [ ] Tested patient deletion
- [ ] Tested validation errors

## Checklist
- [ ] Code builds successfully
- [ ] Tests pass
- [ ] Documentation updated if needed
- [ ] Linked issue is referenced
- [ ] This PR stays within the issue scope

## Summary by Sourcery

Add a patient domain service and REST controller to manage patient records via CRUD operations.

New Features:
- Introduce PatientService to handle creation, retrieval, update, and deletion of patients with room number uniqueness checks.
- Expose patient CRUD operations through PatientController REST endpoints under /api/v1/patients.