### PR TITLE
Feature/device entity repository

### DIFF
--- a/backend/src/main/java/com/iothealth/backend/entity/Device.java
+++ b/backend/src/main/java/com/iothealth/backend/entity/Device.java
@@ -1,4 +1,61 @@
 package com.iothealth.backend.entity;
 
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.Instant;
+
+@Entity
+@Table(
+        name = "devices",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_devices_device_code", columnNames = "device_code")
+        }
+)
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class Device {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "device_code", nullable = false, length = 50, unique = true)
+    private String deviceCode;
+
+    @Column(nullable = false, length = 100)
+    private String type;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private DeviceStatus status;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "patient_id", nullable = false, unique = true)
+    private Patient patient;
+
+    @Column(nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @Column(nullable = false)
+    private Instant updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        Instant now = Instant.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+
+        if (this.status == null) {
+            this.status = DeviceStatus.ACTIVE;
+        }
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = Instant.now();
+    }
 }

--- a/backend/src/main/java/com/iothealth/backend/entity/Device.java
+++ b/backend/src/main/java/com/iothealth/backend/entity/Device.java
@@ -23,7 +23,7 @@ public class Device {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "device_code", nullable = false, length = 50, unique = true)
+    @Column(name = "device_code", nullable = false, length = 50)
     private String deviceCode;
 
     @Column(nullable = false, length = 100)

--- a/backend/src/main/java/com/iothealth/backend/entity/Device.java
+++ b/backend/src/main/java/com/iothealth/backend/entity/Device.java
@@ -1,0 +1,4 @@
+package com.iothealth.backend.entity;
+
+public class Device {
+}

--- a/backend/src/main/java/com/iothealth/backend/entity/DeviceStatus.java
+++ b/backend/src/main/java/com/iothealth/backend/entity/DeviceStatus.java
@@ -1,0 +1,4 @@
+package com.iothealth.backend.entity;
+
+public class DeviceStatus {
+}

--- a/backend/src/main/java/com/iothealth/backend/entity/DeviceStatus.java
+++ b/backend/src/main/java/com/iothealth/backend/entity/DeviceStatus.java
@@ -1,4 +1,7 @@
 package com.iothealth.backend.entity;
 
-public class DeviceStatus {
+public enum DeviceStatus {
+    ACTIVE,
+    INACTIVE,
+    MAINTENANCE
 }

--- a/backend/src/main/java/com/iothealth/backend/repository/DeviceRepository.java
+++ b/backend/src/main/java/com/iothealth/backend/repository/DeviceRepository.java
@@ -1,7 +1,6 @@
 package com.iothealth.backend.repository;
 
 import com.iothealth.backend.entity.Device;
-import com.iothealth.backend.entity.Patient;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -10,9 +9,9 @@ public interface DeviceRepository extends JpaRepository<Device, Long> {
 
     Optional<Device> findByDeviceCode(String deviceCode);
 
-    Optional<Device> findByPatient(Patient patient);
+    Optional<Device> findByPatientId(Long patientId);
 
     boolean existsByDeviceCode(String deviceCode);
 
-    boolean existsByPatient(Patient patient);
+    boolean existsByPatientId(Long patientId);
 }

--- a/backend/src/main/java/com/iothealth/backend/repository/DeviceRepository.java
+++ b/backend/src/main/java/com/iothealth/backend/repository/DeviceRepository.java
@@ -1,4 +1,18 @@
 package com.iothealth.backend.repository;
 
-public class DeviceRepository {
+import com.iothealth.backend.entity.Device;
+import com.iothealth.backend.entity.Patient;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface DeviceRepository extends JpaRepository<Device, Long> {
+
+    Optional<Device> findByDeviceCode(String deviceCode);
+
+    Optional<Device> findByPatient(Patient patient);
+
+    boolean existsByDeviceCode(String deviceCode);
+
+    boolean existsByPatient(Patient patient);
 }

--- a/backend/src/main/java/com/iothealth/backend/repository/DeviceRepository.java
+++ b/backend/src/main/java/com/iothealth/backend/repository/DeviceRepository.java
@@ -1,0 +1,4 @@
+package com.iothealth.backend.repository;
+
+public class DeviceRepository {
+}


### PR DESCRIPTION
## Summary
Adds the Device persistence layer.

## Related Issue
Closes #27

## Changes
- Added Device entity
- Added DeviceStatus enum
- Added DeviceRepository
- Linked Device to Patient with a one-to-one relationship
- Added database uniqueness constraints for device code and patient assignment

## Testing
- [ ] Ran `./mvnw clean test`

## Checklist
- [ ] Code builds successfully
- [ ] Tests pass
- [ ] Documentation updated if needed
- [ ] Linked issue is referenced
- [ ] This PR stays within the issue scope

## Summary by Sourcery

Introduce persistence support for medical devices, including their status and association with patients.

New Features:
- Add Device JPA entity with metadata, status and timestamps for persistence.
- Define DeviceStatus enum to represent device lifecycle states.
- Create DeviceRepository with lookup and existence checks by device code and patient.
- Link Device to Patient via a one-to-one relationship with uniqueness constraints on device code and patient assignment.