### PR TITLE
feat: implement device service and controller

### DIFF
--- a/backend/src/main/java/com/iothealth/backend/controller/DeviceController.java
+++ b/backend/src/main/java/com/iothealth/backend/controller/DeviceController.java
@@ -1,0 +1,59 @@
+package com.iothealth.backend.controller;
+
+import com.iothealth.backend.dto.device.DeviceRequest;
+import com.iothealth.backend.dto.device.DeviceResponse;
+import com.iothealth.backend.service.DeviceService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/devices")
+@RequiredArgsConstructor
+public class DeviceController {
+
+    private final DeviceService deviceService;
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public DeviceResponse createDevice(@Valid @RequestBody DeviceRequest request) {
+        return deviceService.createDevice(request);
+    }
+
+    @GetMapping
+    public List<DeviceResponse> getAllDevices() {
+        return deviceService.getAllDevices();
+    }
+
+    @GetMapping("/{id}")
+    public DeviceResponse getDeviceById(@PathVariable Long id) {
+        return deviceService.getDeviceById(id);
+    }
+
+    @GetMapping("/code/{deviceCode}")
+    public DeviceResponse getDeviceByCode(@PathVariable String deviceCode) {
+        return deviceService.getDeviceByCode(deviceCode);
+    }
+
+    @GetMapping("/patient/{patientId}")
+    public DeviceResponse getDeviceByPatientId(@PathVariable Long patientId) {
+        return deviceService.getDeviceByPatientId(patientId);
+    }
+
+    @PutMapping("/{id}")
+    public DeviceResponse updateDevice(
+            @PathVariable Long id,
+            @Valid @RequestBody DeviceRequest request
+    ) {
+        return deviceService.updateDevice(id, request);
+    }
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteDevice(@PathVariable Long id) {
+        deviceService.deleteDevice(id);
+    }
+}

--- a/backend/src/main/java/com/iothealth/backend/service/DeviceService.java
+++ b/backend/src/main/java/com/iothealth/backend/service/DeviceService.java
@@ -102,7 +102,7 @@ public class DeviceService {
 
     private void validatePatientHasNoDevice(Long patientId) {
         if (deviceRepository.existsByPatientId(patientId)) {
-            throw new BadRequestException("Patient already has an assigned device with id: " + patientId);
+            throw new BadRequestException("Patient already has an assigned device: patientId=" + patientId);
         }
     }
 }

--- a/backend/src/main/java/com/iothealth/backend/service/DeviceService.java
+++ b/backend/src/main/java/com/iothealth/backend/service/DeviceService.java
@@ -1,0 +1,108 @@
+package com.iothealth.backend.service;
+
+import com.iothealth.backend.dto.device.DeviceRequest;
+import com.iothealth.backend.dto.device.DeviceResponse;
+import com.iothealth.backend.entity.Device;
+import com.iothealth.backend.entity.Patient;
+import com.iothealth.backend.exception.BadRequestException;
+import com.iothealth.backend.exception.ResourceNotFoundException;
+import com.iothealth.backend.mapper.DeviceMapper;
+import com.iothealth.backend.repository.DeviceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class DeviceService {
+
+    private final DeviceRepository deviceRepository;
+    private final PatientService patientService;
+
+    public DeviceResponse createDevice(DeviceRequest request) {
+        validateDeviceCodeIsUnique(request.deviceCode());
+        validatePatientHasNoDevice(request.patientId());
+
+        Patient patient = patientService.findPatientEntityById(request.patientId());
+
+        Device device = DeviceMapper.toEntity(request, patient);
+        Device savedDevice = deviceRepository.save(device);
+
+        return DeviceMapper.toResponse(savedDevice);
+    }
+
+    @Transactional(readOnly = true)
+    public List<DeviceResponse> getAllDevices() {
+        return deviceRepository.findAll()
+                .stream()
+                .map(DeviceMapper::toResponse)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public DeviceResponse getDeviceById(Long id) {
+        Device device = findDeviceEntityById(id);
+        return DeviceMapper.toResponse(device);
+    }
+
+    @Transactional(readOnly = true)
+    public DeviceResponse getDeviceByCode(String deviceCode) {
+        Device device = deviceRepository.findByDeviceCode(deviceCode)
+                .orElseThrow(() -> new ResourceNotFoundException("Device not found with code: " + deviceCode));
+
+        return DeviceMapper.toResponse(device);
+    }
+
+    @Transactional(readOnly = true)
+    public DeviceResponse getDeviceByPatientId(Long patientId) {
+        Device device = deviceRepository.findByPatientId(patientId)
+                .orElseThrow(() -> new ResourceNotFoundException("Device not found for patient id: " + patientId));
+
+        return DeviceMapper.toResponse(device);
+    }
+
+    public DeviceResponse updateDevice(Long id, DeviceRequest request) {
+        Device existingDevice = findDeviceEntityById(id);
+
+        if (!existingDevice.getDeviceCode().equals(request.deviceCode())) {
+            validateDeviceCodeIsUnique(request.deviceCode());
+        }
+
+        if (!existingDevice.getPatient().getId().equals(request.patientId())) {
+            validatePatientHasNoDevice(request.patientId());
+        }
+
+        Patient patient = patientService.findPatientEntityById(request.patientId());
+
+        DeviceMapper.updateEntity(existingDevice, request, patient);
+        Device updatedDevice = deviceRepository.save(existingDevice);
+
+        return DeviceMapper.toResponse(updatedDevice);
+    }
+
+    public void deleteDevice(Long id) {
+        Device device = findDeviceEntityById(id);
+        deviceRepository.delete(device);
+    }
+
+    @Transactional(readOnly = true)
+    public Device findDeviceEntityById(Long id) {
+        return deviceRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Device not found with id: " + id));
+    }
+
+    private void validateDeviceCodeIsUnique(String deviceCode) {
+        if (deviceRepository.existsByDeviceCode(deviceCode)) {
+            throw new BadRequestException("Device code already exists: " + deviceCode);
+        }
+    }
+
+    private void validatePatientHasNoDevice(Long patientId) {
+        if (deviceRepository.existsByPatientId(patientId)) {
+            throw new BadRequestException("Patient already has an assigned device with id: " + patientId);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Implements the Device service and REST controller.

## Related Issue
Closes #29

## Changes
- Added DeviceService with CRUD operations
- Added DeviceController with REST endpoints
- Added lookup by device code
- Added lookup by patient ID
- Added device code uniqueness validation
- Added patient-device assignment validation

## Testing
- [x] Ran `./mvnw clean test`
- [x] Tested device creation
- [x] Tested device listing
- [x] Tested device lookup by ID
- [x] Tested device lookup by code
- [x] Tested device lookup by patient ID
- [x] Tested device update
- [x] Tested device deletion
- [x] Tested duplicate device code validation
- [x] Tested duplicate patient assignment validation

## Checklist
- [x] Code builds successfully
- [x] Tests pass
- [ ] Documentation updated if needed
- [x] Linked issue is referenced
- [x] This PR stays within the issue scope

## Summary by Sourcery

Add backend support for managing devices via a dedicated service and REST controller.

New Features:
- Introduce DeviceService providing CRUD operations and lookups by device code and patient ID.
- Expose device management REST endpoints under /api/v1/devices for creation, retrieval, update, and deletion.

Enhancements:
- Enforce uniqueness of device codes and prevent multiple device assignments per patient at the service layer.