### PR TITLE
feat: add vital sign entity and repository

### DIFF
--- a/backend/src/main/java/com/iothealth/backend/entity/VitalSign.java
+++ b/backend/src/main/java/com/iothealth/backend/entity/VitalSign.java
@@ -1,0 +1,59 @@
+package com.iothealth.backend.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+@Entity
+@Table(
+        name = "vital_signs",
+        indexes = {
+                @Index(name = "idx_vital_signs_patient_recorded_at", columnList = "patient_id, recorded_at"),
+                @Index(name = "idx_vital_signs_device_recorded_at", columnList = "device_id, recorded_at")
+        }
+)
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class VitalSign {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "heart_rate", nullable = false)
+    private Integer heartRate;
+
+    @Column(nullable = false, precision = 4, scale = 1)
+    private BigDecimal temperature;
+
+    @Column(nullable = false)
+    private Integer spo2;
+
+    @Column(name = "recorded_at", nullable = false)
+    private Instant recordedAt;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "patient_id", nullable = false)
+    private Patient patient;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "device_id", nullable = false)
+    private Device device;
+
+    @PrePersist
+    protected void onCreate() {
+        if (this.recordedAt == null) {
+            this.recordedAt = Instant.now();
+        }
+
+        this.createdAt = Instant.now();
+    }
+}

--- a/backend/src/main/java/com/iothealth/backend/entity/VitalSign.java
+++ b/backend/src/main/java/com/iothealth/backend/entity/VitalSign.java
@@ -37,6 +37,7 @@ public class VitalSign {
     @Column(name = "recorded_at", nullable = false)
     private Instant recordedAt;
 
+    @Setter(AccessLevel.NONE)
     @Column(name = "created_at", nullable = false, updatable = false)
     private Instant createdAt;
 
@@ -50,10 +51,12 @@ public class VitalSign {
 
     @PrePersist
     protected void onCreate() {
+        Instant now = Instant.now();
+
         if (this.recordedAt == null) {
-            this.recordedAt = Instant.now();
+            this.recordedAt = now;
         }
 
-        this.createdAt = Instant.now();
+        this.createdAt = now;
     }
 }

--- a/backend/src/main/java/com/iothealth/backend/repository/VitalSignRepository.java
+++ b/backend/src/main/java/com/iothealth/backend/repository/VitalSignRepository.java
@@ -1,0 +1,23 @@
+package com.iothealth.backend.repository;
+
+import com.iothealth.backend.entity.VitalSign;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+public interface VitalSignRepository extends JpaRepository<VitalSign, Long> {
+
+    Optional<VitalSign> findTopByPatientIdOrderByRecordedAtDesc(Long patientId);
+
+    List<VitalSign> findByPatientIdOrderByRecordedAtDesc(Long patientId);
+
+    List<VitalSign> findByPatientIdAndRecordedAtBetweenOrderByRecordedAtDesc(
+            Long patientId,
+            Instant from,
+            Instant to
+    );
+
+    List<VitalSign> findByDeviceDeviceCodeOrderByRecordedAtDesc(String deviceCode);
+}


### PR DESCRIPTION
## Summary
Adds the VitalSign persistence layer for storing patient vital sign readings.

## Related Issue
Closes #31

## Changes
- Added VitalSign entity
- Linked vital signs to Patient and Device
- Added indexes for patient/device recorded-at queries
- Added VitalSignRepository query methods for latest readings and history

## Testing
- [ ] Ran `./mvnw clean test`

## Checklist
- [ ] Code builds successfully
- [ ] Tests pass
- [ ] Documentation updated if needed
- [ ] Linked issue is referenced
- [ ] This PR stays within the issue scope

## Summary by Sourcery

Introduce persistence support for patient vital sign readings linked to patients and devices.

New Features:
- Add VitalSign JPA entity to store heart rate, temperature, oxygen saturation, and timestamps for readings.
- Add VitalSignRepository with query methods for latest and historical patient and device vital sign data.

Enhancements:
- Add database indexes on patient and device with recorded-at timestamps to optimize vital sign lookup queries.