### PR TITLE
feat: add vital sign ingestion DTOs

### DIFF
--- a/backend/src/main/java/com/iothealth/backend/dto/vitalsign/VitalSignRequest.java
+++ b/backend/src/main/java/com/iothealth/backend/dto/vitalsign/VitalSignRequest.java
@@ -1,0 +1,37 @@
+package com.iothealth.backend.dto.vitalsign;
+
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+public record VitalSignRequest(
+
+        @NotBlank(message = "Device code is required")
+        @Size(max = 50, message = "Device code must not exceed 50 characters")
+        String deviceCode,
+
+        @NotNull(message = "Heart rate is required")
+        @Min(value = 30, message = "Heart rate must be at least 30 bpm")
+        @Max(value = 220, message = "Heart rate must not exceed 220 bpm")
+        Integer heartRate,
+
+        @NotNull(message = "Temperature is required")
+        @DecimalMin(value = "30.0", message = "Temperature must be at least 30.0°C")
+        @DecimalMax(value = "45.0", message = "Temperature must not exceed 45.0°C")
+        BigDecimal temperature,
+
+        @NotNull(message = "SpO2 is required")
+        @Min(value = 50, message = "SpO2 must be at least 50%")
+        @Max(value = 100, message = "SpO2 must not exceed 100%")
+        Integer spo2,
+
+        Instant recordedAt
+) {
+}

--- a/backend/src/main/java/com/iothealth/backend/dto/vitalsign/VitalSignResponse.java
+++ b/backend/src/main/java/com/iothealth/backend/dto/vitalsign/VitalSignResponse.java
@@ -1,0 +1,18 @@
+package com.iothealth.backend.dto.vitalsign;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+public record VitalSignResponse(
+        Long id,
+        Long patientId,
+        String patientFullName,
+        Long deviceId,
+        String deviceCode,
+        Integer heartRate,
+        BigDecimal temperature,
+        Integer spo2,
+        Instant recordedAt,
+        Instant createdAt
+) {
+}

--- a/backend/src/main/java/com/iothealth/backend/mapper/VitalSignMapper.java
+++ b/backend/src/main/java/com/iothealth/backend/mapper/VitalSignMapper.java
@@ -5,6 +5,9 @@ import com.iothealth.backend.dto.vitalsign.VitalSignResponse;
 import com.iothealth.backend.entity.Device;
 import com.iothealth.backend.entity.Patient;
 import com.iothealth.backend.entity.VitalSign;
+import com.iothealth.backend.exception.BadRequestException;
+
+import java.time.Instant;
 
 public final class VitalSignMapper {
 
@@ -14,13 +17,17 @@ public final class VitalSignMapper {
     public static VitalSign toEntity(VitalSignRequest request, Device device) {
         Patient patient = device.getPatient();
 
+        if (patient == null) {
+            throw new BadRequestException("Device is not assigned to a patient: deviceCode=" + device.getDeviceCode());
+        }
+
         return VitalSign.builder()
                 .device(device)
                 .patient(patient)
                 .heartRate(request.heartRate())
                 .temperature(request.temperature())
                 .spo2(request.spo2())
-                .recordedAt(request.recordedAt())
+                .recordedAt(request.recordedAt() != null ? request.recordedAt() : Instant.now())
                 .build();
     }
 

--- a/backend/src/main/java/com/iothealth/backend/mapper/VitalSignMapper.java
+++ b/backend/src/main/java/com/iothealth/backend/mapper/VitalSignMapper.java
@@ -1,0 +1,57 @@
+package com.iothealth.backend.mapper;
+
+import com.iothealth.backend.dto.vitalsign.VitalSignRequest;
+import com.iothealth.backend.dto.vitalsign.VitalSignResponse;
+import com.iothealth.backend.entity.Device;
+import com.iothealth.backend.entity.Patient;
+import com.iothealth.backend.entity.VitalSign;
+
+public final class VitalSignMapper {
+
+    private VitalSignMapper() {
+    }
+
+    public static VitalSign toEntity(VitalSignRequest request, Device device) {
+        Patient patient = device.getPatient();
+
+        return VitalSign.builder()
+                .device(device)
+                .patient(patient)
+                .heartRate(request.heartRate())
+                .temperature(request.temperature())
+                .spo2(request.spo2())
+                .recordedAt(request.recordedAt())
+                .build();
+    }
+
+    public static VitalSignResponse toResponse(VitalSign vitalSign) {
+        Patient patient = vitalSign.getPatient();
+        Device device = vitalSign.getDevice();
+
+        return new VitalSignResponse(
+                vitalSign.getId(),
+                patient != null ? patient.getId() : null,
+                formatPatientFullName(patient),
+                device != null ? device.getId() : null,
+                device != null ? device.getDeviceCode() : null,
+                vitalSign.getHeartRate(),
+                vitalSign.getTemperature(),
+                vitalSign.getSpo2(),
+                vitalSign.getRecordedAt(),
+                vitalSign.getCreatedAt()
+        );
+    }
+
+    private static String formatPatientFullName(Patient patient) {
+        if (patient == null) {
+            return null;
+        }
+
+        String firstName = patient.getFirstName() != null ? patient.getFirstName().trim() : "";
+        String lastName = patient.getLastName() != null ? patient.getLastName().trim() : "";
+
+        String fullName = (firstName + " " + lastName).trim();
+
+        return fullName.isBlank() ? null : fullName;
+    }
+}


### PR DESCRIPTION
## Summary
Adds VitalSign request and response DTOs for sensor data ingestion.

## Related Issue
Closes #32

## Changes
- Added VitalSignRequest DTO with validation constraints
- Added VitalSignResponse DTO
- Added VitalSignMapper for entity/DTO conversion
- Mapped incoming sensor data through deviceCode

## Testing
- [ ] Ran `./mvnw clean test`

## Checklist
- [ ] Code builds successfully
- [ ] Tests pass
- [ ] Documentation updated if needed
- [ ] Linked issue is referenced
- [ ] This PR stays within the issue scope

## Summary by Sourcery

Add DTOs and mapping logic to support ingestion and exposure of vital sign data linked to devices and patients.

New Features:
- Introduce VitalSignRequest DTO with validation constraints for incoming sensor readings.
- Introduce VitalSignResponse DTO to expose vital sign data along with related patient and device details.
- Add VitalSignMapper to convert between VitalSign entities and the new request/response DTOs.