### PR TITLE
feat: implement vital signs ingestion endpoint

### DIFF
--- a/backend/src/main/java/com/iothealth/backend/controller/VitalSignController.java
+++ b/backend/src/main/java/com/iothealth/backend/controller/VitalSignController.java
@@ -1,0 +1,23 @@
+package com.iothealth.backend.controller;
+
+import com.iothealth.backend.dto.vitalsign.VitalSignRequest;
+import com.iothealth.backend.dto.vitalsign.VitalSignResponse;
+import com.iothealth.backend.service.VitalSignService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/vitals")
+@RequiredArgsConstructor
+public class VitalSignController {
+
+    private final VitalSignService vitalSignService;
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public VitalSignResponse ingestVitalSign(@Valid @RequestBody VitalSignRequest request) {
+        return vitalSignService.ingestVitalSign(request);
+    }
+}

--- a/backend/src/main/java/com/iothealth/backend/service/VitalSignService.java
+++ b/backend/src/main/java/com/iothealth/backend/service/VitalSignService.java
@@ -1,0 +1,34 @@
+package com.iothealth.backend.service;
+
+import com.iothealth.backend.dto.vitalsign.VitalSignRequest;
+import com.iothealth.backend.dto.vitalsign.VitalSignResponse;
+import com.iothealth.backend.entity.Device;
+import com.iothealth.backend.entity.VitalSign;
+import com.iothealth.backend.exception.ResourceNotFoundException;
+import com.iothealth.backend.mapper.VitalSignMapper;
+import com.iothealth.backend.repository.DeviceRepository;
+import com.iothealth.backend.repository.VitalSignRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class VitalSignService {
+
+    private final VitalSignRepository vitalSignRepository;
+    private final DeviceRepository deviceRepository;
+
+    public VitalSignResponse ingestVitalSign(VitalSignRequest request) {
+        Device device = deviceRepository.findByDeviceCode(request.deviceCode())
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Device not found with code: " + request.deviceCode()
+                ));
+
+        VitalSign vitalSign = VitalSignMapper.toEntity(request, device);
+        VitalSign savedVitalSign = vitalSignRepository.save(vitalSign);
+
+        return VitalSignMapper.toResponse(savedVitalSign);
+    }
+}


### PR DESCRIPTION
## Summary
Implements the vital signs ingestion API used by virtual sensors.

## Related Issue
Closes #33

## Changes
- Added VitalSignService
- Added VitalSignController
- Added POST /api/v1/vitals endpoint
- Resolved patient and device associations through deviceCode
- Stored incoming vital signs in PostgreSQL

## Testing
- [ ] Ran `./mvnw clean test`
- [ ] Tested valid vital sign ingestion
- [ ] Tested ingestion without recordedAt
- [ ] Tested unknown deviceCode handling
- [ ] Tested validation errors

## Checklist
- [ ] Code builds successfully
- [ ] Tests pass
- [ ] Documentation updated if needed
- [ ] Linked issue is referenced
- [ ] This PR stays within the issue scope

## Summary by Sourcery

Add backend support for ingesting vital sign data from devices via a new REST endpoint.

New Features:
- Introduce a VitalSignService to handle ingestion and persistence of vital sign data associated with devices.
- Expose a POST /api/v1/vitals endpoint for clients to submit vital sign measurements.