### PR TITLE
feat: add latest vital sign endpoint

### DIFF
--- a/backend/src/main/java/com/iothealth/backend/controller/VitalSignController.java
+++ b/backend/src/main/java/com/iothealth/backend/controller/VitalSignController.java
@@ -20,4 +20,9 @@ public class VitalSignController {
     public VitalSignResponse ingestVitalSign(@Valid @RequestBody VitalSignRequest request) {
         return vitalSignService.ingestVitalSign(request);
     }
+
+    @GetMapping("/patient/{patientId}/latest")
+    public VitalSignResponse getLatestVitalSignByPatientId(@PathVariable Long patientId) {
+        return vitalSignService.getLatestVitalSignByPatientId(patientId);
+    }
 }

--- a/backend/src/main/java/com/iothealth/backend/service/VitalSignService.java
+++ b/backend/src/main/java/com/iothealth/backend/service/VitalSignService.java
@@ -31,4 +31,14 @@ public class VitalSignService {
 
         return VitalSignMapper.toResponse(savedVitalSign);
     }
+
+    @Transactional(readOnly = true)
+    public VitalSignResponse getLatestVitalSignByPatientId(Long patientId) {
+        VitalSign vitalSign = vitalSignRepository.findTopByPatientIdOrderByRecordedAtDesc(patientId)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "No vital sign readings found for patient id: " + patientId
+                ));
+
+        return VitalSignMapper.toResponse(vitalSign);
+    }
 }


### PR DESCRIPTION
## Summary
Adds an endpoint for retrieving the latest vital sign reading for a patient.

## Related Issue
Closes #34

## Changes
- Added latest vital sign lookup in VitalSignService
- Added GET /api/v1/vitals/patient/{patientId}/latest
- Returns 404 when no vital sign readings exist for the patient

## Testing
- [ ] Ran `./mvnw clean test`
- [ ] Tested latest vital sign lookup for patient with readings
- [ ] Tested latest vital sign lookup for patient without readings

## Checklist
- [ ] Code builds successfully
- [ ] Tests pass
- [ ] Documentation updated if needed
- [ ] Linked issue is referenced
- [ ] This PR stays within the issue scope

## Summary by Sourcery

Add an API endpoint to retrieve the latest vital sign reading for a patient.

New Features:
- Expose GET /api/v1/vitals/patient/{patientId}/latest to return the most recent vital sign reading for a given patient.
- Support fetching the latest vital sign for a patient in VitalSignService, returning a not-found response when no readings exist.