### PR TITLE
feat: add vital signs history endpoint

### DIFF
--- a/backend/src/main/java/com/iothealth/backend/controller/VitalSignController.java
+++ b/backend/src/main/java/com/iothealth/backend/controller/VitalSignController.java
@@ -7,6 +7,9 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.format.annotation.DateTimeFormat;
+import java.time.Instant;
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/vitals")
@@ -24,5 +27,19 @@ public class VitalSignController {
     @GetMapping("/patient/{patientId}/latest")
     public VitalSignResponse getLatestVitalSignByPatientId(@PathVariable Long patientId) {
         return vitalSignService.getLatestVitalSignByPatientId(patientId);
+    }
+
+    @GetMapping("/patient/{patientId}/history")
+    public List<VitalSignResponse> getVitalSignHistoryByPatientId(
+            @PathVariable Long patientId,
+            @RequestParam(required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+            Instant from,
+
+            @RequestParam(required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+            Instant to
+    ) {
+        return vitalSignService.getVitalSignHistoryByPatientId(patientId, from, to);
     }
 }

--- a/backend/src/main/java/com/iothealth/backend/controller/VitalSignController.java
+++ b/backend/src/main/java/com/iothealth/backend/controller/VitalSignController.java
@@ -7,7 +7,6 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.format.annotation.DateTimeFormat;
 import java.time.Instant;
 import java.util.List;
 
@@ -32,14 +31,10 @@ public class VitalSignController {
     @GetMapping("/patient/{patientId}/history")
     public List<VitalSignResponse> getVitalSignHistoryByPatientId(
             @PathVariable Long patientId,
-            @RequestParam(required = false)
-            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-            Instant from,
-
-            @RequestParam(required = false)
-            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-            Instant to
+            @RequestParam(required = false) Instant from,
+            @RequestParam(required = false) Instant to,
+            @RequestParam(defaultValue = "100") int limit
     ) {
-        return vitalSignService.getVitalSignHistoryByPatientId(patientId, from, to);
+        return vitalSignService.getVitalSignHistoryByPatientId(patientId, from, to, limit);
     }
 }

--- a/backend/src/main/java/com/iothealth/backend/repository/VitalSignRepository.java
+++ b/backend/src/main/java/com/iothealth/backend/repository/VitalSignRepository.java
@@ -1,6 +1,7 @@
 package com.iothealth.backend.repository;
 
 import com.iothealth.backend.entity.VitalSign;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.Instant;
@@ -11,12 +12,13 @@ public interface VitalSignRepository extends JpaRepository<VitalSign, Long> {
 
     Optional<VitalSign> findTopByPatientIdOrderByRecordedAtDesc(Long patientId);
 
-    List<VitalSign> findByPatientIdOrderByRecordedAtDesc(Long patientId);
+    List<VitalSign> findByPatientIdOrderByRecordedAtDesc(Long patientId, Pageable pageable);
 
     List<VitalSign> findByPatientIdAndRecordedAtBetweenOrderByRecordedAtDesc(
             Long patientId,
             Instant from,
-            Instant to
+            Instant to,
+            Pageable pageable
     );
 
     List<VitalSign> findByDeviceDeviceCodeOrderByRecordedAtDesc(String deviceCode);

--- a/backend/src/main/java/com/iothealth/backend/service/VitalSignService.java
+++ b/backend/src/main/java/com/iothealth/backend/service/VitalSignService.java
@@ -4,6 +4,7 @@ import com.iothealth.backend.dto.vitalsign.VitalSignRequest;
 import com.iothealth.backend.dto.vitalsign.VitalSignResponse;
 import com.iothealth.backend.entity.Device;
 import com.iothealth.backend.entity.VitalSign;
+import com.iothealth.backend.exception.BadRequestException;
 import com.iothealth.backend.exception.ResourceNotFoundException;
 import com.iothealth.backend.mapper.VitalSignMapper;
 import com.iothealth.backend.repository.DeviceRepository;
@@ -11,6 +12,9 @@ import com.iothealth.backend.repository.VitalSignRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -41,4 +45,37 @@ public class VitalSignService {
 
         return VitalSignMapper.toResponse(vitalSign);
     }
+
+    @Transactional(readOnly = true)
+    public List<VitalSignResponse> getVitalSignHistoryByPatientId(
+            Long patientId,
+            Instant from,
+            Instant to
+    ) {
+        if ((from == null && to != null) || (from != null && to == null)) {
+            throw new BadRequestException("Both 'from' and 'to' timestamps must be provided together");
+        }
+
+        List<VitalSign> vitalSigns;
+
+        if (from != null) {
+            if (from.isAfter(to)) {
+                throw new BadRequestException("'from' timestamp must be before 'to' timestamp");
+            }
+
+            vitalSigns = vitalSignRepository.findByPatientIdAndRecordedAtBetweenOrderByRecordedAtDesc(
+                    patientId,
+                    from,
+                    to
+            );
+        } else {
+            vitalSigns = vitalSignRepository.findByPatientIdOrderByRecordedAtDesc(patientId);
+        }
+
+        return vitalSigns.stream()
+                .map(VitalSignMapper::toResponse)
+                .toList();
+    }
+
+
 }

--- a/backend/src/main/java/com/iothealth/backend/service/VitalSignService.java
+++ b/backend/src/main/java/com/iothealth/backend/service/VitalSignService.java
@@ -12,6 +12,8 @@ import com.iothealth.backend.repository.VitalSignRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 import java.time.Instant;
 import java.util.List;
@@ -50,31 +52,44 @@ public class VitalSignService {
     public List<VitalSignResponse> getVitalSignHistoryByPatientId(
             Long patientId,
             Instant from,
-            Instant to
+            Instant to,
+            int limit
     ) {
         if ((from == null && to != null) || (from != null && to == null)) {
             throw new BadRequestException("Both 'from' and 'to' timestamps must be provided together");
         }
 
+        if (from != null && from.isAfter(to)) {
+            throw new BadRequestException("'from' timestamp must be before 'to' timestamp");
+        }
+
+        int sanitizedLimit = sanitizeLimit(limit);
+        Pageable pageable = PageRequest.of(0, sanitizedLimit);
+
         List<VitalSign> vitalSigns;
 
         if (from != null) {
-            if (from.isAfter(to)) {
-                throw new BadRequestException("'from' timestamp must be before 'to' timestamp");
-            }
-
             vitalSigns = vitalSignRepository.findByPatientIdAndRecordedAtBetweenOrderByRecordedAtDesc(
                     patientId,
                     from,
-                    to
+                    to,
+                    pageable
             );
         } else {
-            vitalSigns = vitalSignRepository.findByPatientIdOrderByRecordedAtDesc(patientId);
+            vitalSigns = vitalSignRepository.findByPatientIdOrderByRecordedAtDesc(patientId, pageable);
         }
 
         return vitalSigns.stream()
                 .map(VitalSignMapper::toResponse)
                 .toList();
+    }
+
+    private int sanitizeLimit(int limit) {
+        if (limit < 1) {
+            throw new BadRequestException("'limit' must be greater than 0");
+        }
+
+        return Math.min(limit, 500);
     }
 
 


### PR DESCRIPTION
## Summary
Adds a patient vital signs history endpoint with optional date range filtering.

## Related Issue
Closes #35

## Changes
- Added patient vital signs history lookup in VitalSignService
- Added GET /api/v1/vitals/patient/{patientId}/history
- Added optional `from` and `to` date range filters
- Added validation for incomplete or invalid date ranges

## Testing
- [ ] Ran `./mvnw clean test`
- [ ] Tested full patient vital signs history lookup
- [ ] Tested filtered history by date range
- [ ] Tested invalid date range handling

## Checklist
- [ ] Code builds successfully
- [ ] Tests pass
- [ ] Documentation updated if needed
- [ ] Linked issue is referenced
- [ ] This PR stays within the issue scope

## Summary by Sourcery

Add an endpoint to retrieve a patient’s vital sign history with optional date range filtering and validation.

New Features:
- Expose GET /api/v1/vitals/patient/{patientId}/history to return a patient’s vital sign history.
- Support optional ISO-8601 `from` and `to` query parameters to filter vital sign history by recorded timestamp.

Enhancements:
- Validate date range inputs, rejecting requests with only one bound provided or with `from` after `to`.