### PR TITLE
feat: add alert entity and repository

### DIFF
--- a/backend/src/main/java/com/iothealth/backend/entity/Alert.java
+++ b/backend/src/main/java/com/iothealth/backend/entity/Alert.java
@@ -11,7 +11,9 @@ import java.time.Instant;
         indexes = {
                 @Index(name = "idx_alerts_patient_created_at", columnList = "patient_id, created_at"),
                 @Index(name = "idx_alerts_resolved_created_at", columnList = "resolved, created_at"),
-                @Index(name = "idx_alerts_severity_created_at", columnList = "severity, created_at")
+                @Index(name = "idx_alerts_severity_created_at", columnList = "severity, created_at"),
+                @Index(name = "idx_alerts_type_created_at", columnList = "type, created_at"),
+                @Index(name = "idx_alerts_vital_sign_created_at", columnList = "vital_sign_id, created_at")
         }
 )
 @Getter
@@ -37,7 +39,7 @@ public class Alert {
     private String message;
 
     @Column(nullable = false)
-    private Boolean resolved;
+    private boolean resolved;
 
     @Column(name = "created_at", nullable = false, updatable = false)
     @Setter(AccessLevel.NONE)
@@ -61,14 +63,10 @@ public class Alert {
     @PrePersist
     protected void onCreate() {
         this.createdAt = Instant.now();
-
-        if (this.resolved == null) {
-            this.resolved = false;
-        }
     }
 
     public void resolve() {
-        if (!Boolean.TRUE.equals(this.resolved)) {
+        if (!this.resolved) {
             this.resolved = true;
             this.resolvedAt = Instant.now();
         }

--- a/backend/src/main/java/com/iothealth/backend/entity/Alert.java
+++ b/backend/src/main/java/com/iothealth/backend/entity/Alert.java
@@ -1,0 +1,76 @@
+package com.iothealth.backend.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.Instant;
+
+@Entity
+@Table(
+        name = "alerts",
+        indexes = {
+                @Index(name = "idx_alerts_patient_created_at", columnList = "patient_id, created_at"),
+                @Index(name = "idx_alerts_resolved_created_at", columnList = "resolved, created_at"),
+                @Index(name = "idx_alerts_severity_created_at", columnList = "severity, created_at")
+        }
+)
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Alert {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 50)
+    private AlertType type;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private AlertSeverity severity;
+
+    @Column(nullable = false, length = 500)
+    private String message;
+
+    @Column(nullable = false)
+    private Boolean resolved;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    @Setter(AccessLevel.NONE)
+    private Instant createdAt;
+
+    @Column(name = "resolved_at")
+    private Instant resolvedAt;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "patient_id", nullable = false)
+    private Patient patient;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "device_id", nullable = false)
+    private Device device;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "vital_sign_id", nullable = false)
+    private VitalSign vitalSign;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = Instant.now();
+
+        if (this.resolved == null) {
+            this.resolved = false;
+        }
+    }
+
+    public void resolve() {
+        if (!Boolean.TRUE.equals(this.resolved)) {
+            this.resolved = true;
+            this.resolvedAt = Instant.now();
+        }
+    }
+}

--- a/backend/src/main/java/com/iothealth/backend/entity/AlertSeverity.java
+++ b/backend/src/main/java/com/iothealth/backend/entity/AlertSeverity.java
@@ -1,0 +1,6 @@
+package com.iothealth.backend.entity;
+
+public enum AlertSeverity {
+    WARNING,
+    CRITICAL
+}

--- a/backend/src/main/java/com/iothealth/backend/entity/AlertType.java
+++ b/backend/src/main/java/com/iothealth/backend/entity/AlertType.java
@@ -1,0 +1,9 @@
+package com.iothealth.backend.entity;
+
+public enum AlertType {
+    HIGH_HEART_RATE,
+    LOW_HEART_RATE,
+    HIGH_TEMPERATURE,
+    LOW_TEMPERATURE,
+    LOW_SPO2
+}

--- a/backend/src/main/java/com/iothealth/backend/repository/AlertRepository.java
+++ b/backend/src/main/java/com/iothealth/backend/repository/AlertRepository.java
@@ -1,0 +1,23 @@
+package com.iothealth.backend.repository;
+
+import com.iothealth.backend.entity.Alert;
+import com.iothealth.backend.entity.AlertSeverity;
+import com.iothealth.backend.entity.AlertType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface AlertRepository extends JpaRepository<Alert, Long> {
+
+    List<Alert> findByPatientIdOrderByCreatedAtDesc(Long patientId);
+
+    List<Alert> findByResolvedFalseOrderByCreatedAtDesc();
+
+    List<Alert> findByPatientIdAndResolvedFalseOrderByCreatedAtDesc(Long patientId);
+
+    List<Alert> findBySeverityOrderByCreatedAtDesc(AlertSeverity severity);
+
+    List<Alert> findByTypeOrderByCreatedAtDesc(AlertType type);
+
+    List<Alert> findByVitalSignIdOrderByCreatedAtDesc(Long vitalSignId);
+}


### PR DESCRIPTION
## Summary
Adds the Alert persistence layer.

## Related Issue
Closes #36

## Changes
- Added Alert entity
- Added AlertType enum
- Added AlertSeverity enum
- Linked alerts to Patient, Device, and VitalSign
- Added AlertRepository query methods
- Added indexes for patient, resolved status, and severity queries

## Testing
- [ ] Ran `./mvnw clean test`

## Checklist
- [ ] Code builds successfully
- [ ] Tests pass
- [ ] Documentation updated if needed
- [ ] Linked issue is referenced
- [ ] This PR stays within the issue scope

## Summary by Sourcery

Introduce a persistence model and repository for alerts associated with patients, devices, and vital signs.

New Features:
- Add Alert JPA entity with type, severity, message, resolution status, timestamps, and relations to patient, device, and vital sign.
- Add AlertType and AlertSeverity enums to categorize alert kinds and criticality.
- Add AlertRepository with query methods for common lookup patterns by patient, resolution status, severity, type, and vital sign.

Enhancements:
- Add database indexes on alerts for patient, resolution status, and severity ordered by creation time to optimize common queries.