### PR TITLE
feat: implement alert API endpoints

### DIFF
--- a/backend/src/main/java/com/iothealth/backend/controller/AlertController.java
+++ b/backend/src/main/java/com/iothealth/backend/controller/AlertController.java
@@ -1,0 +1,36 @@
+package com.iothealth.backend.controller;
+
+import com.iothealth.backend.dto.alert.AlertResponse;
+import com.iothealth.backend.service.AlertService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/alerts")
+@RequiredArgsConstructor
+public class AlertController {
+
+    private final AlertService alertService;
+
+    @GetMapping
+    public List<AlertResponse> getAllAlerts() {
+        return alertService.getAllAlerts();
+    }
+
+    @GetMapping("/unresolved")
+    public List<AlertResponse> getUnresolvedAlerts() {
+        return alertService.getUnresolvedAlerts();
+    }
+
+    @GetMapping("/patient/{patientId}")
+    public List<AlertResponse> getAlertsByPatientId(@PathVariable Long patientId) {
+        return alertService.getAlertsByPatientId(patientId);
+    }
+
+    @PutMapping("/{id}/resolve")
+    public AlertResponse resolveAlert(@PathVariable Long id) {
+        return alertService.resolveAlert(id);
+    }
+}

--- a/backend/src/main/java/com/iothealth/backend/dto/alert/AlertResponse.java
+++ b/backend/src/main/java/com/iothealth/backend/dto/alert/AlertResponse.java
@@ -1,0 +1,22 @@
+package com.iothealth.backend.dto.alert;
+
+import com.iothealth.backend.entity.AlertSeverity;
+import com.iothealth.backend.entity.AlertType;
+
+import java.time.Instant;
+
+public record AlertResponse(
+        Long id,
+        AlertType type,
+        AlertSeverity severity,
+        String message,
+        boolean resolved,
+        Instant createdAt,
+        Instant resolvedAt,
+        Long patientId,
+        String patientFullName,
+        Long deviceId,
+        String deviceCode,
+        Long vitalSignId
+) {
+}

--- a/backend/src/main/java/com/iothealth/backend/mapper/AlertMapper.java
+++ b/backend/src/main/java/com/iothealth/backend/mapper/AlertMapper.java
@@ -1,0 +1,47 @@
+package com.iothealth.backend.mapper;
+
+import com.iothealth.backend.dto.alert.AlertResponse;
+import com.iothealth.backend.entity.Alert;
+import com.iothealth.backend.entity.Device;
+import com.iothealth.backend.entity.Patient;
+import com.iothealth.backend.entity.VitalSign;
+
+public final class AlertMapper {
+
+    private AlertMapper() {
+    }
+
+    public static AlertResponse toResponse(Alert alert) {
+        Patient patient = alert.getPatient();
+        Device device = alert.getDevice();
+        VitalSign vitalSign = alert.getVitalSign();
+
+        return new AlertResponse(
+                alert.getId(),
+                alert.getType(),
+                alert.getSeverity(),
+                alert.getMessage(),
+                alert.isResolved(),
+                alert.getCreatedAt(),
+                alert.getResolvedAt(),
+                patient != null ? patient.getId() : null,
+                formatPatientFullName(patient),
+                device != null ? device.getId() : null,
+                device != null ? device.getDeviceCode() : null,
+                vitalSign != null ? vitalSign.getId() : null
+        );
+    }
+
+    private static String formatPatientFullName(Patient patient) {
+        if (patient == null) {
+            return null;
+        }
+
+        String firstName = patient.getFirstName() != null ? patient.getFirstName().trim() : "";
+        String lastName = patient.getLastName() != null ? patient.getLastName().trim() : "";
+
+        String fullName = (firstName + " " + lastName).trim();
+
+        return fullName.isBlank() ? null : fullName;
+    }
+}

--- a/backend/src/main/java/com/iothealth/backend/service/AlertService.java
+++ b/backend/src/main/java/com/iothealth/backend/service/AlertService.java
@@ -8,6 +8,7 @@ import com.iothealth.backend.entity.Patient;
 import com.iothealth.backend.entity.VitalSign;
 import com.iothealth.backend.repository.AlertRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import com.iothealth.backend.dto.alert.AlertResponse;
@@ -144,7 +145,7 @@ public class AlertService {
 
     @Transactional(readOnly = true)
     public List<AlertResponse> getAllAlerts() {
-        return alertRepository.findAll()
+        return alertRepository.findAll(Sort.by(Sort.Direction.DESC, "createdAt"))
                 .stream()
                 .map(AlertMapper::toResponse)
                 .toList();
@@ -166,6 +167,7 @@ public class AlertService {
                 .toList();
     }
 
+    @Transactional
     public AlertResponse resolveAlert(Long id) {
         Alert alert = alertRepository.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("Alert not found with id: " + id));

--- a/backend/src/main/java/com/iothealth/backend/service/AlertService.java
+++ b/backend/src/main/java/com/iothealth/backend/service/AlertService.java
@@ -10,6 +10,9 @@ import com.iothealth.backend.repository.AlertRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import com.iothealth.backend.dto.alert.AlertResponse;
+import com.iothealth.backend.exception.ResourceNotFoundException;
+import com.iothealth.backend.mapper.AlertMapper;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -137,6 +140,41 @@ public class AlertService {
                     "Warning low SpO2 detected: " + spo2 + "%"
             ));
         }
+    }
+
+    @Transactional(readOnly = true)
+    public List<AlertResponse> getAllAlerts() {
+        return alertRepository.findAll()
+                .stream()
+                .map(AlertMapper::toResponse)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<AlertResponse> getUnresolvedAlerts() {
+        return alertRepository.findByResolvedFalseOrderByCreatedAtDesc()
+                .stream()
+                .map(AlertMapper::toResponse)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<AlertResponse> getAlertsByPatientId(Long patientId) {
+        return alertRepository.findByPatientIdOrderByCreatedAtDesc(patientId)
+                .stream()
+                .map(AlertMapper::toResponse)
+                .toList();
+    }
+
+    public AlertResponse resolveAlert(Long id) {
+        Alert alert = alertRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Alert not found with id: " + id));
+
+        alert.resolve();
+
+        Alert savedAlert = alertRepository.save(alert);
+
+        return AlertMapper.toResponse(savedAlert);
     }
 
     private Alert buildAlert(


### PR DESCRIPTION
## Summary
Implements REST API endpoints for alert retrieval and resolution.

## Related Issue
Closes #39

## Changes
- Added AlertResponse DTO
- Added AlertMapper
- Added endpoints to list all alerts
- Added endpoint to list unresolved alerts
- Added endpoint to get alerts by patient ID
- Added endpoint to resolve alerts

## Testing
- [ ] Ran `./mvnw clean test`
- [ ] Tested alert creation through vital sign ingestion
- [ ] Tested listing all alerts
- [ ] Tested listing unresolved alerts
- [ ] Tested listing alerts by patient ID
- [ ] Tested resolving an alert

## Checklist
- [ ] Code builds successfully
- [ ] Tests pass
- [ ] Documentation updated if needed
- [ ] Linked issue is referenced
- [ ] This PR stays within the issue scope

## Summary by Sourcery

Expose REST API endpoints for listing and resolving alerts backed by a new alert response DTO and mapper.

New Features:
- Add AlertResponse DTO for returning alert data with patient, device, and vital sign context.
- Introduce AlertMapper to convert Alert entities into AlertResponse records.
- Add AlertController with endpoints to list all alerts, unresolved alerts, alerts by patient, and resolve an alert via the service layer.

Enhancements:
- Extend AlertService with read-only methods for retrieving alerts and a method to resolve alerts, returning AlertResponse objects.