### PR TITLE
feat: configure websocket support

### DIFF
--- a/backend/src/main/java/com/iothealth/backend/config/WebSocketConfig.java
+++ b/backend/src/main/java/com/iothealth/backend/config/WebSocketConfig.java
@@ -1,0 +1,29 @@
+package com.iothealth.backend.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    private static final String WEBSOCKET_ENDPOINT = "/ws";
+    private static final String TOPIC_PREFIX = "/topic";
+    private static final String APPLICATION_PREFIX = "/app";
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.enableSimpleBroker(TOPIC_PREFIX);
+        registry.setApplicationDestinationPrefixes(APPLICATION_PREFIX);
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint(WEBSOCKET_ENDPOINT)
+                .setAllowedOriginPatterns("*")
+                .withSockJS();
+    }
+}

--- a/backend/src/main/java/com/iothealth/backend/config/WebSocketConfig.java
+++ b/backend/src/main/java/com/iothealth/backend/config/WebSocketConfig.java
@@ -1,10 +1,14 @@
 package com.iothealth.backend.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.util.StringUtils;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+import java.util.Arrays;
 
 @Configuration
 @EnableWebSocketMessageBroker
@@ -13,6 +17,18 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     private static final String WEBSOCKET_ENDPOINT = "/ws";
     private static final String TOPIC_PREFIX = "/topic";
     private static final String APPLICATION_PREFIX = "/app";
+
+    private final String[] allowedOrigins;
+
+    public WebSocketConfig(
+            @Value("${app.websocket.allowed-origins:http://localhost:5173,http://localhost:3000}")
+            String allowedOrigins
+    ) {
+        this.allowedOrigins = Arrays.stream(allowedOrigins.split(","))
+                .map(String::trim)
+                .filter(StringUtils::hasText)
+                .toArray(String[]::new);
+    }
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
@@ -23,7 +39,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint(WEBSOCKET_ENDPOINT)
-                .setAllowedOriginPatterns("*")
+                .setAllowedOriginPatterns(allowedOrigins)
                 .withSockJS();
     }
 }

--- a/backend/src/main/resources/application.example.yml
+++ b/backend/src/main/resources/application.example.yml
@@ -23,3 +23,9 @@ management:
     web:
       exposure:
         include: health,info
+
+app:
+  websocket:
+    allowed-origins:
+      - http://localhost:5173
+      - http://localhost:3000


### PR DESCRIPTION
## Summary
Configures backend WebSocket/STOMP support for future real-time vital sign and alert updates.

## Related Issue
Closes #40

## Changes
- Added WebSocketConfig
- Enabled STOMP WebSocket message broker
- Registered `/ws` WebSocket endpoint
- Configured `/topic` for server-to-client messages
- Configured `/app` for client-to-server messages

## Testing
- [ ] Ran `./mvnw clean test`

## Checklist
- [ ] Code builds successfully
- [ ] Tests pass
- [ ] Documentation updated if needed
- [ ] Linked issue is referenced
- [ ] This PR stays within the issue scope

## Summary by Sourcery

Configure backend WebSocket messaging support using STOMP for real-time communication.

New Features:
- Introduce WebSocketConfig to enable STOMP-based WebSocket messaging.
- Expose a `/ws` WebSocket endpoint with SockJS fallback for client connections.
- Configure `/topic` for brokered server-to-client messages and `/app` as the application destination prefix for client-to-server messages.