### PR TITLE
feat: broadcast new vital signs over websocket

### DIFF
--- a/backend/src/main/java/com/iothealth/backend/service/VitalSignService.java
+++ b/backend/src/main/java/com/iothealth/backend/service/VitalSignService.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import com.iothealth.backend.websocket.VitalSignWebSocketPublisher;
 
 import java.time.Instant;
 import java.util.List;
@@ -26,6 +27,7 @@ public class VitalSignService {
     private final VitalSignRepository vitalSignRepository;
     private final DeviceRepository deviceRepository;
     private final AlertService alertService;
+    private final VitalSignWebSocketPublisher vitalSignWebSocketPublisher;
 
     public VitalSignResponse ingestVitalSign(VitalSignRequest request) {
         Device device = deviceRepository.findByDeviceCode(request.deviceCode())
@@ -38,7 +40,10 @@ public class VitalSignService {
 
         alertService.detectAndCreateAlerts(savedVitalSign);
 
-        return VitalSignMapper.toResponse(savedVitalSign);
+        VitalSignResponse response = VitalSignMapper.toResponse(savedVitalSign);
+        vitalSignWebSocketPublisher.publishVitalSign(response);
+
+        return response;
     }
 
     @Transactional(readOnly = true)

--- a/backend/src/main/java/com/iothealth/backend/websocket/VitalSignWebSocketPublisher.java
+++ b/backend/src/main/java/com/iothealth/backend/websocket/VitalSignWebSocketPublisher.java
@@ -1,0 +1,25 @@
+package com.iothealth.backend.websocket;
+
+import com.iothealth.backend.dto.vitalsign.VitalSignResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class VitalSignWebSocketPublisher {
+
+    private static final String GLOBAL_VITALS_TOPIC = "/topic/vitals";
+    private static final String PATIENT_VITALS_TOPIC_TEMPLATE = "/topic/patients/%d/vitals";
+
+    private final SimpMessagingTemplate messagingTemplate;
+
+    public void publishVitalSign(VitalSignResponse response) {
+        messagingTemplate.convertAndSend(GLOBAL_VITALS_TOPIC, response);
+
+        if (response.patientId() != null) {
+            String patientTopic = String.format(PATIENT_VITALS_TOPIC_TEMPLATE, response.patientId());
+            messagingTemplate.convertAndSend(patientTopic, response);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Broadcasts new vital sign readings over WebSocket after successful ingestion.

## Related Issue
Closes #41

## Changes
- Added VitalSignWebSocketPublisher
- Published new vital signs to `/topic/vitals`
- Published patient-specific vital signs to `/topic/patients/{patientId}/vitals`
- Integrated WebSocket publishing into VitalSignService

## Testing
- [ ] Ran `./mvnw clean test`
- [ ] Tested vital sign ingestion still succeeds
- [ ] Verified no WebSocket publishing errors appear in backend logs

## Checklist
- [ ] Code builds successfully
- [ ] Tests pass
- [ ] Documentation updated if needed
- [ ] Linked issue is referenced
- [ ] This PR stays within the issue scope

## Summary by Sourcery

Broadcast vital sign ingestion events over WebSocket topics for global and patient-specific subscribers.

New Features:
- Introduce a WebSocket publisher component for vital sign updates.
- Publish all new vital sign readings to a global "/topic/vitals" destination.
- Publish patient-specific vital sign readings to "/topic/patients/{patientId}/vitals" after successful ingestion.