### PR TITLE
feat: broadcast new alerts over websocket

### DIFF
--- a/backend/src/main/java/com/iothealth/backend/service/AlertService.java
+++ b/backend/src/main/java/com/iothealth/backend/service/AlertService.java
@@ -14,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.iothealth.backend.dto.alert.AlertResponse;
 import com.iothealth.backend.exception.ResourceNotFoundException;
 import com.iothealth.backend.mapper.AlertMapper;
+import com.iothealth.backend.websocket.AlertWebSocketPublisher;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -36,6 +37,8 @@ public class AlertService {
     private static final int LOW_SPO2_CRITICAL = 92;
 
     private final AlertRepository alertRepository;
+    private final AlertWebSocketPublisher alertWebSocketPublisher;
+
 
     public List<Alert> detectAndCreateAlerts(VitalSign vitalSign) {
         List<Alert> alerts = detectAlerts(vitalSign);
@@ -44,7 +47,13 @@ public class AlertService {
             return List.of();
         }
 
-        return alertRepository.saveAll(alerts);
+        List<Alert> savedAlerts = alertRepository.saveAll(alerts);
+
+        savedAlerts.stream()
+                .map(AlertMapper::toResponse)
+                .forEach(alertWebSocketPublisher::publishAlert);
+
+        return savedAlerts;
     }
 
     private List<Alert> detectAlerts(VitalSign vitalSign) {

--- a/backend/src/main/java/com/iothealth/backend/websocket/AlertWebSocketPublisher.java
+++ b/backend/src/main/java/com/iothealth/backend/websocket/AlertWebSocketPublisher.java
@@ -2,11 +2,13 @@ package com.iothealth.backend.websocket;
 
 import com.iothealth.backend.dto.alert.AlertResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class AlertWebSocketPublisher {
 
     private static final String GLOBAL_ALERTS_TOPIC = "/topic/alerts";
@@ -15,11 +17,20 @@ public class AlertWebSocketPublisher {
     private final SimpMessagingTemplate messagingTemplate;
 
     public void publishAlert(AlertResponse response) {
-        messagingTemplate.convertAndSend(GLOBAL_ALERTS_TOPIC, response);
+        try {
+            messagingTemplate.convertAndSend(GLOBAL_ALERTS_TOPIC, response);
 
-        if (response.patientId() != null) {
-            String patientTopic = String.format(PATIENT_ALERTS_TOPIC_TEMPLATE, response.patientId());
-            messagingTemplate.convertAndSend(patientTopic, response);
+            if (response.patientId() != null) {
+                String patientTopic = String.format(PATIENT_ALERTS_TOPIC_TEMPLATE, response.patientId());
+                messagingTemplate.convertAndSend(patientTopic, response);
+            }
+        } catch (Exception exception) {
+            log.warn(
+                    "Failed to publish alert WebSocket event. alertId={}, patientId={}",
+                    response.id(),
+                    response.patientId(),
+                    exception
+            );
         }
     }
 }

--- a/backend/src/main/java/com/iothealth/backend/websocket/AlertWebSocketPublisher.java
+++ b/backend/src/main/java/com/iothealth/backend/websocket/AlertWebSocketPublisher.java
@@ -1,0 +1,25 @@
+package com.iothealth.backend.websocket;
+
+import com.iothealth.backend.dto.alert.AlertResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AlertWebSocketPublisher {
+
+    private static final String GLOBAL_ALERTS_TOPIC = "/topic/alerts";
+    private static final String PATIENT_ALERTS_TOPIC_TEMPLATE = "/topic/patients/%d/alerts";
+
+    private final SimpMessagingTemplate messagingTemplate;
+
+    public void publishAlert(AlertResponse response) {
+        messagingTemplate.convertAndSend(GLOBAL_ALERTS_TOPIC, response);
+
+        if (response.patientId() != null) {
+            String patientTopic = String.format(PATIENT_ALERTS_TOPIC_TEMPLATE, response.patientId());
+            messagingTemplate.convertAndSend(patientTopic, response);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Broadcasts newly created alerts over WebSocket when abnormal vital signs are detected.

## Related Issue
Closes #42

## Changes
- Added AlertWebSocketPublisher
- Published new alerts to `/topic/alerts`
- Published patient-specific alerts to `/topic/patients/{patientId}/alerts`
- Integrated alert WebSocket publishing into AlertService

## Testing
- [ ] Ran `./mvnw clean test`
- [ ] Tested abnormal vital sign ingestion
- [ ] Verified alert is created
- [ ] Verified no WebSocket publishing errors appear in backend logs

## Checklist
- [ ] Code builds successfully
- [ ] Tests pass
- [ ] Documentation updated if needed
- [ ] Linked issue is referenced
- [ ] This PR stays within the issue scope

## Summary by Sourcery

Broadcast new alerts over WebSocket when abnormal vital signs are detected and alerts are created.

New Features:
- Introduce an AlertWebSocketPublisher component to send alert messages over STOMP topics.
- Publish newly created alerts to a global alerts topic and patient-specific alert topics in real time.

Enhancements:
- Integrate WebSocket alert publishing into the existing AlertService alert creation workflow.