### PR TITLE
feat: build patient detail page

### DIFF
--- a/frontend/src/api/alertApi.js
+++ b/frontend/src/api/alertApi.js
@@ -1,0 +1,8 @@
+import { httpClient } from "./httpClient";
+
+export const alertApi = {
+  getByPatientId: (patientId) =>
+    httpClient.get(`/alerts/patient/${patientId}`).then((res) => res.data),
+  resolve: (alertId) =>
+    httpClient.put(`/alerts/${alertId}/resolve`).then((res) => res.data),
+};

--- a/frontend/src/api/vitalSignApi.js
+++ b/frontend/src/api/vitalSignApi.js
@@ -5,4 +5,9 @@ export const vitalSignApi = {
     httpClient
       .get(`/vitals/patient/${patientId}/latest`)
       .then((res) => res.data),
+
+  getHistoryByPatientId: (patientId, limit = 20) =>
+    httpClient
+      .get(`/vitals/patient/${patientId}/history`, { params: { limit } })
+      .then((res) => res.data),
 };

--- a/frontend/src/components/detail/PatientAlerts.jsx
+++ b/frontend/src/components/detail/PatientAlerts.jsx
@@ -1,0 +1,54 @@
+import { useState } from "react";
+import { alertApi } from "../../api/alertApi";
+
+export function PatientAlerts({ alerts, onAlertResolved }) {
+  const [resolvingId, setResolvingId] = useState(null);
+
+  async function handleResolve(alertId) {
+    setResolvingId(alertId);
+    try {
+      const updated = await alertApi.resolve(alertId);
+      onAlertResolved(updated);
+    } catch {
+      alert("Failed to resolve alert. Please try again.");
+    } finally {
+      setResolvingId(null);
+    }
+  }
+
+  if (!alerts || alerts.length === 0) {
+    return <p className="no-data">No alerts for this patient.</p>;
+  }
+
+  return (
+    <div className="alerts-list">
+      {alerts.map((a) => (
+        <div
+          key={a.id}
+          className={`alert-item alert-item--${a.severity.toLowerCase()} ${a.resolved ? "alert-item--resolved" : ""}`}
+        >
+          <div className="alert-item__header">
+            <span className="alert-item__type">{a.type}</span>
+            <span className="alert-item__severity">{a.severity}</span>
+            {a.resolved && <span className="alert-item__badge">Resolved</span>}
+          </div>
+          <p className="alert-item__message">{a.message}</p>
+          <div className="alert-item__footer">
+            <span className="alert-item__time">
+              {new Date(a.createdAt).toLocaleString()}
+            </span>
+            {!a.resolved && (
+              <button
+                className="btn btn--small"
+                onClick={() => handleResolve(a.id)}
+                disabled={resolvingId === a.id}
+              >
+                {resolvingId === a.id ? "Resolving…" : "Resolve"}
+              </button>
+            )}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/detail/VitalsHistory.jsx
+++ b/frontend/src/components/detail/VitalsHistory.jsx
@@ -1,0 +1,30 @@
+export function VitalsHistory({ vitals }) {
+  if (!vitals || vitals.length === 0) {
+    return <p className="no-data">No vitals history recorded.</p>;
+  }
+
+  return (
+    <div className="vitals-history">
+      <table className="vitals-table">
+        <thead>
+          <tr>
+            <th>Recorded At</th>
+            <th>Heart Rate (bpm)</th>
+            <th>Temperature (°C)</th>
+            <th>SpO2 (%)</th>
+          </tr>
+        </thead>
+        <tbody>
+          {vitals.map((v) => (
+            <tr key={v.id}>
+              <td>{new Date(v.recordedAt).toLocaleString()}</td>
+              <td>{v.heartRate ?? "—"}</td>
+              <td>{v.temperature ?? "—"}</td>
+              <td>{v.spo2 ?? "—"}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/src/hooks/usePatientDetail.js
+++ b/frontend/src/hooks/usePatientDetail.js
@@ -1,0 +1,50 @@
+import { useState, useEffect } from "react";
+import { patientApi } from "../api/patientApi";
+import { vitalSignApi } from "../api/vitalSignApi";
+import { alertApi } from "../api/alertApi";
+
+export function usePatientDetail(patientId) {
+  const [patient, setPatient] = useState(null);
+  const [vitalsHistory, setVitalsHistory] = useState([]);
+  const [alerts, setAlerts] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (!patientId) return;
+    let cancelled = false;
+
+    async function fetchAll() {
+      try {
+        setLoading(true);
+        setError(null);
+
+        const [patientData, historyData, alertsData] = await Promise.all([
+          patientApi.getById(patientId),
+          vitalSignApi.getHistoryByPatientId(patientId, 20),
+          alertApi.getByPatientId(patientId),
+        ]);
+
+        if (cancelled) return;
+        setPatient(patientData);
+        setVitalsHistory(historyData);
+        setAlerts(alertsData);
+      } catch (err) {
+        if (!cancelled) setError("Failed to load patient data.");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    fetchAll();
+    return () => { cancelled = true; };
+  }, [patientId]);
+
+  function handleAlertResolved(updatedAlert) {
+    setAlerts((prev) =>
+      prev.map((a) => (a.id === updatedAlert.id ? updatedAlert : a))
+    );
+  }
+
+  return { patient, vitalsHistory, alerts, loading, error, handleAlertResolved };
+}

--- a/frontend/src/pages/PatientDetailPage.jsx
+++ b/frontend/src/pages/PatientDetailPage.jsx
@@ -1,12 +1,68 @@
-import { useParams } from "react-router-dom";
+import { useParams, Link } from "react-router-dom";
+import { usePatientDetail } from "../hooks/usePatientDetail";
+import { VitalsHistory } from "../components/detail/VitalsHistory";
+import { PatientAlerts } from "../components/detail/PatientAlerts";
 
 export function PatientDetailPage() {
   const { patientId } = useParams();
+  const { patient, vitalsHistory, alerts, loading, error, handleAlertResolved } =
+    usePatientDetail(patientId);
+
+  if (loading) {
+    return (
+      <section>
+        <p>Loading patient…</p>
+      </section>
+    );
+  }
+
+  if (error) {
+    return (
+      <section>
+        <p className="error">{error}</p>
+        <Link to="/">← Back to dashboard</Link>
+      </section>
+    );
+  }
+
+  if (!patient) return null;
+
+  const fullName = `${patient.firstName} ${patient.lastName}`;
+  const unresolvedCount = alerts.filter((a) => !a.resolved).length;
 
   return (
-    <section>
-      <h2>Patient Details</h2>
-      <p>Patient ID: {patientId}</p>
+    <section className="patient-detail">
+      <div className="patient-detail__back">
+        <Link to="/">← Back to dashboard</Link>
+      </div>
+
+      <div className="patient-detail__header">
+        <h2>{fullName}</h2>
+        <span className="patient-detail__room">Room {patient.roomNumber}</span>
+      </div>
+
+      <div className="patient-detail__info">
+        <span>{patient.age} yrs</span>
+        <span>{patient.gender}</span>
+        {patient.medicalCondition && <span>{patient.medicalCondition}</span>}
+      </div>
+
+      <div className="patient-detail__sections">
+        <div className="patient-detail__section">
+          <h3>Vitals History <span className="section-count">(last 20)</span></h3>
+          <VitalsHistory vitals={vitalsHistory} />
+        </div>
+
+        <div className="patient-detail__section">
+          <h3>
+            Alerts{" "}
+            {unresolvedCount > 0 && (
+              <span className="badge badge--warning">{unresolvedCount} unresolved</span>
+            )}
+          </h3>
+          <PatientAlerts alerts={alerts} onAlertResolved={handleAlertResolved} />
+        </div>
+      </div>
     </section>
   );
 }

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -123,3 +123,133 @@ a {
 .error {
   color: #c0392b;
 }
+
+/* Patient Detail Page */
+.patient-detail__back {
+  margin-bottom: 1rem;
+  font-size: 0.9rem;
+}
+
+.patient-detail__header {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 0.5rem;
+}
+
+.patient-detail__room {
+  font-size: 0.9rem;
+  color: #666;
+  background: #f0f0f0;
+  padding: 2px 8px;
+  border-radius: 4px;
+}
+
+.patient-detail__info {
+  display: flex;
+  gap: 1rem;
+  font-size: 0.9rem;
+  color: #555;
+  margin-bottom: 2rem;
+}
+
+.patient-detail__sections {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.patient-detail__section h3 {
+  margin-bottom: 0.75rem;
+  font-size: 1rem;
+  border-bottom: 1px solid #eee;
+  padding-bottom: 0.4rem;
+}
+
+/* Vitals Table */
+.vitals-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+.vitals-table th,
+.vitals-table td {
+  text-align: left;
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid #f0f0f0;
+}
+
+.vitals-table th {
+  font-weight: 600;
+  color: #444;
+  background: #fafafa;
+}
+
+/* Alerts */
+.alerts-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.alert-item {
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  padding: 0.75rem 1rem;
+  border-left-width: 4px;
+}
+
+.alert-item--critical { border-left-color: #e74c3c; }
+.alert-item--warning  { border-left-color: #f39c12; }
+.alert-item--info     { border-left-color: #3498db; }
+.alert-item--resolved { opacity: 0.6; }
+
+.alert-item__header {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-bottom: 0.25rem;
+}
+
+.alert-item__type     { font-weight: 600; font-size: 0.85rem; }
+.alert-item__severity { font-size: 0.8rem; color: #666; }
+
+.alert-item__badge {
+  font-size: 0.75rem;
+  background: #27ae60;
+  color: #fff;
+  padding: 1px 6px;
+  border-radius: 3px;
+}
+
+.alert-item__message  { font-size: 0.9rem; margin: 0.25rem 0; }
+
+.alert-item__footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 0.5rem;
+}
+
+.alert-item__time { font-size: 0.8rem; color: #999; }
+
+/* Shared */
+.btn {
+  padding: 0.35rem 0.75rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  background: #fff;
+  cursor: pointer;
+  font-size: 0.85rem;
+}
+
+.btn:hover:not(:disabled) { background: #f5f5f5; }
+.btn:disabled { opacity: 0.5; cursor: not-allowed; }
+.btn--small { padding: 0.2rem 0.6rem; font-size: 0.8rem; }
+
+.badge { border-radius: 3px; padding: 1px 6px; font-size: 0.8rem; }
+.badge--warning { background: #f39c12; color: #fff; }
+
+.section-count { font-weight: normal; font-size: 0.85rem; color: #999; }
+.no-data { font-size: 0.9rem; color: #999; }


### PR DESCRIPTION
## Summary
Builds the patient detail page, displaying patient info, vitals history (last 20 readings), and alerts with the ability to resolve them.

## Related Issue
Closes #46

## Changes
- Added `alertApi.js` with `getByPatientId` and `resolve` functions
- Updated `vitalSignApi.js` with `getHistoryByPatientId`
- Added `usePatientDetail` hook fetching patient, vitals history, and alerts in parallel
- Added `VitalsHistory` component displaying vitals in a table
- Added `PatientAlerts` component with per-alert resolve button
- Replaced `PatientDetailPage` placeholder with full implementation
- Added detail page and alert styles to `global.css`

## Testing
- [ ] Backend runs successfully
- [ ] Frontend runs successfully
- [ ] API tested with Postman/Swagger
- [ ] No breaking changes

## Checklist
- [ ] Code builds
- [ ] No direct commit to main
- [ ] Documentation updated if needed

## Summary by Sourcery

Build a patient detail page that shows patient information, vitals history, and alerts with resolve capabilities.

New Features:
- Add patient detail page that displays demographic and room information for a selected patient.
- Add vitals history table component to show the last 20 vital sign readings for a patient.
- Add patient alerts component that lists alerts and allows resolving individual alerts.
- Introduce alert API client for fetching and resolving patient alerts.
- Extend vital signs API client to fetch a limited history of readings by patient ID.
- Add usePatientDetail hook to load patient, vitals history, and alerts in parallel for the detail page.

Enhancements:
- Add global styles for the patient detail layout, vitals table, alerts list, shared buttons, badges, and section counts.