### PR TITLE
test: add backend service tests

### DIFF
--- a/backend/src/test/java/com/iothealth/backend/service/AlertServiceTest.java
+++ b/backend/src/test/java/com/iothealth/backend/service/AlertServiceTest.java
@@ -1,0 +1,284 @@
+package com.iothealth.backend.service;
+
+import com.iothealth.backend.dto.alert.AlertResponse;
+import com.iothealth.backend.entity.*;
+import com.iothealth.backend.exception.ResourceNotFoundException;
+import com.iothealth.backend.repository.AlertRepository;
+import com.iothealth.backend.websocket.AlertWebSocketPublisher;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Sort;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AlertServiceTest {
+
+    @Mock
+    private AlertRepository alertRepository;
+
+    @Mock
+    private AlertWebSocketPublisher alertWebSocketPublisher;
+
+    @InjectMocks
+    private AlertService alertService;
+
+    private Patient patient;
+    private Device device;
+    private VitalSign normalVitalSign;
+
+    @BeforeEach
+    void setUp() {
+        patient = Patient.builder()
+                .id(1L)
+                .firstName("Sara")
+                .lastName("El Amrani")
+                .age(42)
+                .gender(Gender.FEMALE)
+                .roomNumber("A-102")
+                .createdAt(Instant.now())
+                .updatedAt(Instant.now())
+                .build();
+
+        device = Device.builder()
+                .id(1L)
+                .deviceCode("DEV-001")
+                .type("Multi-parameter monitor")
+                .status(DeviceStatus.ACTIVE)
+                .patient(patient)
+                .createdAt(Instant.now())
+                .updatedAt(Instant.now())
+                .build();
+
+        // Normal readings — should produce no alerts
+        normalVitalSign = VitalSign.builder()
+                .id(1L)
+                .patient(patient)
+                .device(device)
+                .heartRate(75)
+                .temperature(BigDecimal.valueOf(36.8))
+                .spo2(98)
+                .recordedAt(Instant.now())
+                .createdAt(Instant.now())
+                .build();
+    }
+
+    // helper
+    private VitalSign vitalSignWith(Integer hr, BigDecimal temp, Integer spo2) {
+        return VitalSign.builder()
+                .id(2L)
+                .patient(patient)
+                .device(device)
+                .heartRate(hr)
+                .temperature(temp)
+                .spo2(spo2)
+                .recordedAt(Instant.now())
+                .createdAt(Instant.now())
+                .build();
+    }
+
+    // --- detectAndCreateAlerts: no alerts ---
+
+    @Test
+    void detectAndCreateAlerts_normalReadings_noAlertsCreated() {
+        List<Alert> result = alertService.detectAndCreateAlerts(normalVitalSign);
+
+        assertThat(result).isEmpty();
+        verify(alertRepository, never()).saveAll(any());
+    }
+
+    // --- Heart rate thresholds ---
+
+    @Test
+    void detectAndCreateAlerts_heartRateCriticalLow_createsCriticalAlert() {
+        VitalSign vs = vitalSignWith(45, BigDecimal.valueOf(36.8), 98); // < 50
+        when(alertRepository.saveAll(anyList())).thenAnswer(inv -> inv.getArgument(0));
+
+        List<Alert> alerts = alertService.detectAndCreateAlerts(vs);
+
+        assertThat(alerts).hasSize(1);
+        assertThat(alerts.get(0).getType()).isEqualTo(AlertType.LOW_HEART_RATE);
+        assertThat(alerts.get(0).getSeverity()).isEqualTo(AlertSeverity.CRITICAL);
+    }
+
+    @Test
+    void detectAndCreateAlerts_heartRateWarningHigh_createsWarningAlert() {
+        VitalSign vs = vitalSignWith(115, BigDecimal.valueOf(36.8), 98); // >= 110, <= 120
+        when(alertRepository.saveAll(anyList())).thenAnswer(inv -> inv.getArgument(0));
+
+        List<Alert> alerts = alertService.detectAndCreateAlerts(vs);
+
+        assertThat(alerts).hasSize(1);
+        assertThat(alerts.get(0).getType()).isEqualTo(AlertType.HIGH_HEART_RATE);
+        assertThat(alerts.get(0).getSeverity()).isEqualTo(AlertSeverity.WARNING);
+    }
+
+    @Test
+    void detectAndCreateAlerts_heartRateCriticalHigh_createsCriticalAlert() {
+        VitalSign vs = vitalSignWith(125, BigDecimal.valueOf(36.8), 98); // > 120
+        when(alertRepository.saveAll(anyList())).thenAnswer(inv -> inv.getArgument(0));
+
+        List<Alert> alerts = alertService.detectAndCreateAlerts(vs);
+
+        assertThat(alerts).hasSize(1);
+        assertThat(alerts.get(0).getType()).isEqualTo(AlertType.HIGH_HEART_RATE);
+        assertThat(alerts.get(0).getSeverity()).isEqualTo(AlertSeverity.CRITICAL);
+    }
+
+    // --- Temperature thresholds ---
+
+    @Test
+    void detectAndCreateAlerts_temperatureCriticalLow_createsCriticalAlert() {
+        VitalSign vs = vitalSignWith(75, BigDecimal.valueOf(34.5), 98); // < 35.0
+        when(alertRepository.saveAll(anyList())).thenAnswer(inv -> inv.getArgument(0));
+
+        List<Alert> alerts = alertService.detectAndCreateAlerts(vs);
+
+        assertThat(alerts).hasSize(1);
+        assertThat(alerts.get(0).getType()).isEqualTo(AlertType.LOW_TEMPERATURE);
+        assertThat(alerts.get(0).getSeverity()).isEqualTo(AlertSeverity.CRITICAL);
+    }
+
+    @Test
+    void detectAndCreateAlerts_temperatureWarningHigh_createsWarningAlert() {
+        VitalSign vs = vitalSignWith(75, BigDecimal.valueOf(37.9), 98); // >= 37.8, <= 38.0
+        when(alertRepository.saveAll(anyList())).thenAnswer(inv -> inv.getArgument(0));
+
+        List<Alert> alerts = alertService.detectAndCreateAlerts(vs);
+
+        assertThat(alerts).hasSize(1);
+        assertThat(alerts.get(0).getType()).isEqualTo(AlertType.HIGH_TEMPERATURE);
+        assertThat(alerts.get(0).getSeverity()).isEqualTo(AlertSeverity.WARNING);
+    }
+
+    @Test
+    void detectAndCreateAlerts_temperatureCriticalHigh_createsCriticalAlert() {
+        VitalSign vs = vitalSignWith(75, BigDecimal.valueOf(38.5), 98); // > 38.0
+        when(alertRepository.saveAll(anyList())).thenAnswer(inv -> inv.getArgument(0));
+
+        List<Alert> alerts = alertService.detectAndCreateAlerts(vs);
+
+        assertThat(alerts).hasSize(1);
+        assertThat(alerts.get(0).getType()).isEqualTo(AlertType.HIGH_TEMPERATURE);
+        assertThat(alerts.get(0).getSeverity()).isEqualTo(AlertSeverity.CRITICAL);
+    }
+
+    // --- SpO2 thresholds ---
+
+    @Test
+    void detectAndCreateAlerts_spo2Warning_createsWarningAlert() {
+        VitalSign vs = vitalSignWith(75, BigDecimal.valueOf(36.8), 93); // <= 94, > 92
+        when(alertRepository.saveAll(anyList())).thenAnswer(inv -> inv.getArgument(0));
+
+        List<Alert> alerts = alertService.detectAndCreateAlerts(vs);
+
+        assertThat(alerts).hasSize(1);
+        assertThat(alerts.get(0).getType()).isEqualTo(AlertType.LOW_SPO2);
+        assertThat(alerts.get(0).getSeverity()).isEqualTo(AlertSeverity.WARNING);
+    }
+
+    @Test
+    void detectAndCreateAlerts_spo2Critical_createsCriticalAlert() {
+        VitalSign vs = vitalSignWith(75, BigDecimal.valueOf(36.8), 90); // <= 92
+        when(alertRepository.saveAll(anyList())).thenAnswer(inv -> inv.getArgument(0));
+
+        List<Alert> alerts = alertService.detectAndCreateAlerts(vs);
+
+        assertThat(alerts).hasSize(1);
+        assertThat(alerts.get(0).getType()).isEqualTo(AlertType.LOW_SPO2);
+        assertThat(alerts.get(0).getSeverity()).isEqualTo(AlertSeverity.CRITICAL);
+    }
+
+    @Test
+    void detectAndCreateAlerts_spo2ExactlyAtCriticalBoundary_createsCriticalAlert() {
+        VitalSign vs = vitalSignWith(75, BigDecimal.valueOf(36.8), 92); // exactly 92 = CRITICAL
+        when(alertRepository.saveAll(anyList())).thenAnswer(inv -> inv.getArgument(0));
+
+        List<Alert> alerts = alertService.detectAndCreateAlerts(vs);
+
+        assertThat(alerts).hasSize(1);
+        assertThat(alerts.get(0).getSeverity()).isEqualTo(AlertSeverity.CRITICAL);
+    }
+
+    // --- Multiple alerts in one reading ---
+
+    @Test
+    void detectAndCreateAlerts_multipleViolations_createsMultipleAlerts() {
+        // High HR critical + low SpO2 critical
+        VitalSign vs = vitalSignWith(130, BigDecimal.valueOf(36.8), 88);
+        when(alertRepository.saveAll(anyList())).thenAnswer(inv -> inv.getArgument(0));
+
+        List<Alert> alerts = alertService.detectAndCreateAlerts(vs);
+
+        assertThat(alerts).hasSize(2);
+        assertThat(alerts).extracting(Alert::getType)
+                .containsExactlyInAnyOrder(AlertType.HIGH_HEART_RATE, AlertType.LOW_SPO2);
+    }
+
+    // --- WebSocket publishing ---
+
+    @Test
+    void detectAndCreateAlerts_alertCreated_publishesViaWebSocket() {
+        VitalSign vs = vitalSignWith(45, BigDecimal.valueOf(36.8), 98);
+        when(alertRepository.saveAll(anyList())).thenAnswer(inv -> inv.getArgument(0));
+
+        alertService.detectAndCreateAlerts(vs);
+
+        verify(alertWebSocketPublisher, atLeastOnce()).publishAlert(any(AlertResponse.class));
+    }
+
+    // --- getAllAlerts ---
+
+    @Test
+    void getAllAlerts_returnsSortedList() {
+        Alert alert = Alert.builder()
+                .id(1L).type(AlertType.HIGH_HEART_RATE).severity(AlertSeverity.WARNING)
+                .message("Warning").resolved(false).patient(patient).device(device)
+                .vitalSign(normalVitalSign).createdAt(Instant.now()).build();
+
+        when(alertRepository.findAll(any(Sort.class))).thenReturn(List.of(alert));
+
+        List<AlertResponse> result = alertService.getAllAlerts();
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).type()).isEqualTo(AlertType.HIGH_HEART_RATE);
+    }
+
+    // --- resolveAlert ---
+
+    @Test
+    void resolveAlert_success() {
+        Alert alert = Alert.builder()
+                .id(1L).type(AlertType.LOW_SPO2).severity(AlertSeverity.CRITICAL)
+                .message("Critical").resolved(false).patient(patient).device(device)
+                .vitalSign(normalVitalSign).createdAt(Instant.now()).build();
+
+        when(alertRepository.findById(1L)).thenReturn(Optional.of(alert));
+        when(alertRepository.save(any(Alert.class))).thenReturn(alert);
+
+        AlertResponse response = alertService.resolveAlert(1L);
+
+        assertThat(response.resolved()).isTrue();
+        verify(alertRepository).save(alert);
+    }
+
+    @Test
+    void resolveAlert_notFound_throwsResourceNotFound() {
+        when(alertRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> alertService.resolveAlert(99L))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("99");
+    }
+}

--- a/backend/src/test/java/com/iothealth/backend/service/DeviceServiceTest.java
+++ b/backend/src/test/java/com/iothealth/backend/service/DeviceServiceTest.java
@@ -1,0 +1,198 @@
+package com.iothealth.backend.service;
+
+import com.iothealth.backend.dto.device.DeviceRequest;
+import com.iothealth.backend.dto.device.DeviceResponse;
+import com.iothealth.backend.entity.Device;
+import com.iothealth.backend.entity.DeviceStatus;
+import com.iothealth.backend.entity.Gender;
+import com.iothealth.backend.entity.Patient;
+import com.iothealth.backend.exception.BadRequestException;
+import com.iothealth.backend.exception.ResourceNotFoundException;
+import com.iothealth.backend.repository.DeviceRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class DeviceServiceTest {
+
+    @Mock
+    private DeviceRepository deviceRepository;
+
+    @Mock
+    private PatientService patientService;
+
+    @InjectMocks
+    private DeviceService deviceService;
+
+    private Patient patient;
+    private Device device;
+    private DeviceRequest request;
+
+    @BeforeEach
+    void setUp() {
+        patient = Patient.builder()
+                .id(1L)
+                .firstName("Sara")
+                .lastName("El Amrani")
+                .age(42)
+                .gender(Gender.FEMALE)
+                .roomNumber("A-102")
+                .createdAt(Instant.now())
+                .updatedAt(Instant.now())
+                .build();
+
+        device = Device.builder()
+                .id(1L)
+                .deviceCode("DEV-001")
+                .type("Multi-parameter monitor")
+                .status(DeviceStatus.ACTIVE)
+                .patient(patient)
+                .createdAt(Instant.now())
+                .updatedAt(Instant.now())
+                .build();
+
+        request = new DeviceRequest("DEV-001", "Multi-parameter monitor", DeviceStatus.ACTIVE, 1L);
+    }
+
+    // --- createDevice ---
+
+    @Test
+    void createDevice_success() {
+        when(deviceRepository.existsByDeviceCode("DEV-001")).thenReturn(false);
+        when(deviceRepository.existsByPatientId(1L)).thenReturn(false);
+        when(patientService.findPatientEntityById(1L)).thenReturn(patient);
+        when(deviceRepository.save(any(Device.class))).thenReturn(device);
+
+        DeviceResponse response = deviceService.createDevice(request);
+
+        assertThat(response.deviceCode()).isEqualTo("DEV-001");
+        assertThat(response.status()).isEqualTo(DeviceStatus.ACTIVE);
+        verify(deviceRepository).save(any(Device.class));
+    }
+
+    @Test
+    void createDevice_duplicateDeviceCode_throwsBadRequest() {
+        when(deviceRepository.existsByDeviceCode("DEV-001")).thenReturn(true);
+
+        assertThatThrownBy(() -> deviceService.createDevice(request))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining("DEV-001");
+
+        verify(deviceRepository, never()).save(any());
+    }
+
+    @Test
+    void createDevice_patientAlreadyHasDevice_throwsBadRequest() {
+        when(deviceRepository.existsByDeviceCode("DEV-001")).thenReturn(false);
+        when(deviceRepository.existsByPatientId(1L)).thenReturn(true);
+
+        assertThatThrownBy(() -> deviceService.createDevice(request))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining("patientId=1");
+
+        verify(deviceRepository, never()).save(any());
+    }
+
+    // --- getAllDevices ---
+
+    @Test
+    void getAllDevices_returnsList() {
+        when(deviceRepository.findAll()).thenReturn(List.of(device));
+
+        List<DeviceResponse> result = deviceService.getAllDevices();
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).deviceCode()).isEqualTo("DEV-001");
+    }
+
+    // --- getDeviceById ---
+
+    @Test
+    void getDeviceById_found_returnsResponse() {
+        when(deviceRepository.findById(1L)).thenReturn(Optional.of(device));
+
+        DeviceResponse response = deviceService.getDeviceById(1L);
+
+        assertThat(response.id()).isEqualTo(1L);
+    }
+
+    @Test
+    void getDeviceById_notFound_throwsResourceNotFound() {
+        when(deviceRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> deviceService.getDeviceById(99L))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("99");
+    }
+
+    // --- getDeviceByCode ---
+
+    @Test
+    void getDeviceByCode_found_returnsResponse() {
+        when(deviceRepository.findByDeviceCode("DEV-001")).thenReturn(Optional.of(device));
+
+        DeviceResponse response = deviceService.getDeviceByCode("DEV-001");
+
+        assertThat(response.deviceCode()).isEqualTo("DEV-001");
+    }
+
+    @Test
+    void getDeviceByCode_notFound_throwsResourceNotFound() {
+        when(deviceRepository.findByDeviceCode("DEV-999")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> deviceService.getDeviceByCode("DEV-999"))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("DEV-999");
+    }
+
+    // --- getDeviceByPatientId ---
+
+    @Test
+    void getDeviceByPatientId_found_returnsResponse() {
+        when(deviceRepository.findByPatientId(1L)).thenReturn(Optional.of(device));
+
+        DeviceResponse response = deviceService.getDeviceByPatientId(1L);
+
+        assertThat(response.patientId()).isEqualTo(1L);
+    }
+
+    @Test
+    void getDeviceByPatientId_notFound_throwsResourceNotFound() {
+        when(deviceRepository.findByPatientId(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> deviceService.getDeviceByPatientId(99L))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("99");
+    }
+
+    // --- deleteDevice ---
+
+    @Test
+    void deleteDevice_success() {
+        when(deviceRepository.findById(1L)).thenReturn(Optional.of(device));
+
+        deviceService.deleteDevice(1L);
+
+        verify(deviceRepository).delete(device);
+    }
+
+    @Test
+    void deleteDevice_notFound_throwsResourceNotFound() {
+        when(deviceRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> deviceService.deleteDevice(99L))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+}

--- a/backend/src/test/java/com/iothealth/backend/service/PatientServiceTest.java
+++ b/backend/src/test/java/com/iothealth/backend/service/PatientServiceTest.java
@@ -1,0 +1,164 @@
+package com.iothealth.backend.service;
+
+import com.iothealth.backend.dto.patient.PatientRequest;
+import com.iothealth.backend.dto.patient.PatientResponse;
+import com.iothealth.backend.entity.Gender;
+import com.iothealth.backend.entity.Patient;
+import com.iothealth.backend.exception.BadRequestException;
+import com.iothealth.backend.exception.ResourceNotFoundException;
+import com.iothealth.backend.repository.PatientRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PatientServiceTest {
+
+    @Mock
+    private PatientRepository patientRepository;
+
+    @InjectMocks
+    private PatientService patientService;
+
+    private Patient patient;
+    private PatientRequest request;
+
+    @BeforeEach
+    void setUp() {
+        patient = Patient.builder()
+                .id(1L)
+                .firstName("Sara")
+                .lastName("El Amrani")
+                .age(42)
+                .gender(Gender.FEMALE)
+                .roomNumber("A-102")
+                .medicalCondition("Cardiac observation")
+                .createdAt(Instant.now())
+                .updatedAt(Instant.now())
+                .build();
+
+        request = new PatientRequest(
+                "Sara", "El Amrani", 42, Gender.FEMALE, "A-102", "Cardiac observation"
+        );
+    }
+
+    // --- createPatient ---
+
+    @Test
+    void createPatient_success() {
+        when(patientRepository.existsByRoomNumber("A-102")).thenReturn(false);
+        when(patientRepository.save(any(Patient.class))).thenReturn(patient);
+
+        PatientResponse response = patientService.createPatient(request);
+
+        assertThat(response.firstName()).isEqualTo("Sara");
+        assertThat(response.roomNumber()).isEqualTo("A-102");
+        verify(patientRepository).save(any(Patient.class));
+    }
+
+    @Test
+    void createPatient_duplicateRoomNumber_throwsBadRequest() {
+        when(patientRepository.existsByRoomNumber("A-102")).thenReturn(true);
+
+        assertThatThrownBy(() -> patientService.createPatient(request))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining("A-102");
+
+        verify(patientRepository, never()).save(any());
+    }
+
+    // --- getAllPatients ---
+
+    @Test
+    void getAllPatients_returnsList() {
+        when(patientRepository.findAll()).thenReturn(List.of(patient));
+
+        List<PatientResponse> result = patientService.getAllPatients();
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).lastName()).isEqualTo("El Amrani");
+    }
+
+    @Test
+    void getAllPatients_empty_returnsEmptyList() {
+        when(patientRepository.findAll()).thenReturn(List.of());
+
+        assertThat(patientService.getAllPatients()).isEmpty();
+    }
+
+    // --- getPatientById ---
+
+    @Test
+    void getPatientById_found_returnsResponse() {
+        when(patientRepository.findById(1L)).thenReturn(Optional.of(patient));
+
+        PatientResponse response = patientService.getPatientById(1L);
+
+        assertThat(response.id()).isEqualTo(1L);
+    }
+
+    @Test
+    void getPatientById_notFound_throwsResourceNotFound() {
+        when(patientRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> patientService.getPatientById(99L))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("99");
+    }
+
+    // --- updatePatient ---
+
+    @Test
+    void updatePatient_sameRoomNumber_success() {
+        when(patientRepository.findById(1L)).thenReturn(Optional.of(patient));
+        when(patientRepository.save(any(Patient.class))).thenReturn(patient);
+
+        PatientResponse response = patientService.updatePatient(1L, request);
+
+        assertThat(response.firstName()).isEqualTo("Sara");
+        verify(patientRepository, never()).existsByRoomNumber(any());
+    }
+
+    @Test
+    void updatePatient_newRoomNumber_alreadyTaken_throwsBadRequest() {
+        PatientRequest newRequest = new PatientRequest(
+                "Sara", "El Amrani", 42, Gender.FEMALE, "B-201", "Cardiac observation"
+        );
+        when(patientRepository.findById(1L)).thenReturn(Optional.of(patient));
+        when(patientRepository.existsByRoomNumber("B-201")).thenReturn(true);
+
+        assertThatThrownBy(() -> patientService.updatePatient(1L, newRequest))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining("B-201");
+    }
+
+    // --- deletePatient ---
+
+    @Test
+    void deletePatient_success() {
+        when(patientRepository.findById(1L)).thenReturn(Optional.of(patient));
+
+        patientService.deletePatient(1L);
+
+        verify(patientRepository).delete(patient);
+    }
+
+    @Test
+    void deletePatient_notFound_throwsResourceNotFound() {
+        when(patientRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> patientService.deletePatient(99L))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+}

--- a/backend/src/test/java/com/iothealth/backend/service/VitalSignServiceTest.java
+++ b/backend/src/test/java/com/iothealth/backend/service/VitalSignServiceTest.java
@@ -1,0 +1,211 @@
+package com.iothealth.backend.service;
+
+import com.iothealth.backend.dto.vitalsign.VitalSignRequest;
+import com.iothealth.backend.dto.vitalsign.VitalSignResponse;
+import com.iothealth.backend.entity.Device;
+import com.iothealth.backend.entity.DeviceStatus;
+import com.iothealth.backend.entity.Gender;
+import com.iothealth.backend.entity.Patient;
+import com.iothealth.backend.entity.VitalSign;
+import com.iothealth.backend.exception.BadRequestException;
+import com.iothealth.backend.exception.ResourceNotFoundException;
+import com.iothealth.backend.repository.DeviceRepository;
+import com.iothealth.backend.repository.VitalSignRepository;
+import com.iothealth.backend.websocket.VitalSignWebSocketPublisher;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class VitalSignServiceTest {
+
+    @Mock
+    private VitalSignRepository vitalSignRepository;
+
+    @Mock
+    private DeviceRepository deviceRepository;
+
+    @Mock
+    private AlertService alertService;
+
+    @Mock
+    private VitalSignWebSocketPublisher vitalSignWebSocketPublisher;
+
+    @InjectMocks
+    private VitalSignService vitalSignService;
+
+    private Patient patient;
+    private Device device;
+    private VitalSign vitalSign;
+    private VitalSignRequest request;
+
+    @BeforeEach
+    void setUp() {
+        patient = Patient.builder()
+                .id(1L)
+                .firstName("Sara")
+                .lastName("El Amrani")
+                .age(42)
+                .gender(Gender.FEMALE)
+                .roomNumber("A-102")
+                .createdAt(Instant.now())
+                .updatedAt(Instant.now())
+                .build();
+
+        device = Device.builder()
+                .id(1L)
+                .deviceCode("DEV-001")
+                .type("Multi-parameter monitor")
+                .status(DeviceStatus.ACTIVE)
+                .patient(patient)
+                .createdAt(Instant.now())
+                .updatedAt(Instant.now())
+                .build();
+
+        vitalSign = VitalSign.builder()
+                .id(1L)
+                .device(device)
+                .patient(patient)
+                .heartRate(75)
+                .temperature(BigDecimal.valueOf(36.8))
+                .spo2(98)
+                .recordedAt(Instant.now())
+                .createdAt(Instant.now())
+                .build();
+
+        request = new VitalSignRequest("DEV-001", 75, BigDecimal.valueOf(36.8), 98, null);
+    }
+
+    // --- ingestVitalSign ---
+
+    @Test
+    void ingestVitalSign_success() {
+        when(deviceRepository.findByDeviceCode("DEV-001")).thenReturn(Optional.of(device));
+        when(vitalSignRepository.save(any(VitalSign.class))).thenReturn(vitalSign);
+        when(alertService.detectAndCreateAlerts(any(VitalSign.class))).thenReturn(List.of());
+
+        VitalSignResponse response = vitalSignService.ingestVitalSign(request);
+
+        assertThat(response.heartRate()).isEqualTo(75);
+        assertThat(response.spo2()).isEqualTo(98);
+        verify(vitalSignRepository).save(any(VitalSign.class));
+        verify(alertService).detectAndCreateAlerts(any(VitalSign.class));
+        verify(vitalSignWebSocketPublisher).publishVitalSign(any(VitalSignResponse.class));
+    }
+
+    @Test
+    void ingestVitalSign_deviceNotFound_throwsResourceNotFound() {
+        when(deviceRepository.findByDeviceCode("DEV-999")).thenReturn(Optional.empty());
+
+        VitalSignRequest badRequest = new VitalSignRequest(
+                "DEV-999", 75, BigDecimal.valueOf(36.8), 98, null
+        );
+
+        assertThatThrownBy(() -> vitalSignService.ingestVitalSign(badRequest))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("DEV-999");
+
+        verify(vitalSignRepository, never()).save(any());
+    }
+
+    @Test
+    void ingestVitalSign_deviceNotAssignedToPatient_throwsBadRequest() {
+        Device unassignedDevice = Device.builder()
+                .id(2L)
+                .deviceCode("DEV-002")
+                .type("Monitor")
+                .status(DeviceStatus.ACTIVE)
+                .patient(null)  // no patient
+                .createdAt(Instant.now())
+                .updatedAt(Instant.now())
+                .build();
+
+        when(deviceRepository.findByDeviceCode("DEV-002"))
+                .thenReturn(Optional.of(unassignedDevice));
+
+        VitalSignRequest badRequest = new VitalSignRequest(
+                "DEV-002", 75, BigDecimal.valueOf(36.8), 98, null
+        );
+
+        assertThatThrownBy(() -> vitalSignService.ingestVitalSign(badRequest))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining("DEV-002");
+    }
+
+    // --- getLatestVitalSignByPatientId ---
+
+    @Test
+    void getLatestVitalSign_found_returnsResponse() {
+        when(vitalSignRepository.findTopByPatientIdOrderByRecordedAtDesc(1L))
+                .thenReturn(Optional.of(vitalSign));
+
+        VitalSignResponse response = vitalSignService.getLatestVitalSignByPatientId(1L);
+
+        assertThat(response.patientId()).isEqualTo(1L);
+        assertThat(response.heartRate()).isEqualTo(75);
+    }
+
+    @Test
+    void getLatestVitalSign_notFound_throwsResourceNotFound() {
+        when(vitalSignRepository.findTopByPatientIdOrderByRecordedAtDesc(99L))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> vitalSignService.getLatestVitalSignByPatientId(99L))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("99");
+    }
+
+    // --- getVitalSignHistoryByPatientId ---
+
+    @Test
+    void getVitalSignHistory_noDateRange_returnsList() {
+        when(vitalSignRepository.findByPatientIdOrderByRecordedAtDesc(eq(1L), any()))
+                .thenReturn(List.of(vitalSign));
+
+        List<VitalSignResponse> result =
+                vitalSignService.getVitalSignHistoryByPatientId(1L, null, null, 10);
+
+        assertThat(result).hasSize(1);
+    }
+
+    @Test
+    void getVitalSignHistory_invalidLimit_throwsBadRequest() {
+        assertThatThrownBy(() ->
+                vitalSignService.getVitalSignHistoryByPatientId(1L, null, null, 0))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining("limit");
+    }
+
+    @Test
+    void getVitalSignHistory_onlyFromProvided_throwsBadRequest() {
+        Instant from = Instant.now().minusSeconds(3600);
+
+        assertThatThrownBy(() ->
+                vitalSignService.getVitalSignHistoryByPatientId(1L, from, null, 10))
+                .isInstanceOf(BadRequestException.class);
+    }
+
+    @Test
+    void getVitalSignHistory_fromAfterTo_throwsBadRequest() {
+        Instant now = Instant.now();
+        Instant from = now;
+        Instant to   = now.minusSeconds(3600);
+
+        assertThatThrownBy(() ->
+                vitalSignService.getVitalSignHistoryByPatientId(1L, from, to, 10))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining("'from'");
+    }
+}


### PR DESCRIPTION
## Summary
Adds unit tests for all four core backend services using JUnit 5 and Mockito.
All tests use mocked dependencies — no real database or Spring context is loaded.

## Related Issue
Closes #54

## Changes
- Added `PatientServiceTest`: create, read, update, delete — success and failure paths
- Added `DeviceServiceTest`: create (duplicate code, patient already assigned), read by id/code/patient, delete
- Added `VitalSignServiceTest`: ingest (device not found, device unassigned), latest, history (limit and date range validation)
- Added `AlertServiceTest`: all threshold boundaries for HR/temperature/SpO2, multiple alerts per reading, WebSocket publishing, resolve

## Testing
- [ ] Backend runs successfully
- [ ] Frontend runs successfully
- [ ] API tested with Postman/Swagger
- [ ] No breaking changes

## Checklist
- [ ] Code builds
- [ ] No direct commit to main
- [ ] Documentation updated if needed

## Summary by Sourcery

Add comprehensive unit test coverage for core backend services including patients, devices, vitals ingestion, and alerts.

Tests:
- Add PatientService tests covering patient CRUD operations, room-number uniqueness, and error handling.
- Add DeviceService tests covering device creation constraints, lookup by id/code/patient, and deletion behavior.
- Add VitalSignService tests covering vitals ingestion, device assignment validation, latest reading retrieval, and history query validation.
- Add AlertService tests covering alert generation thresholds, multiple-alert scenarios, WebSocket publishing, and alert resolution.