### PR TITLE
Feature/backend controller tests

### DIFF
--- a/backend/src/test/java/com/iothealth/backend/controller/AlertControllerTest.java
+++ b/backend/src/test/java/com/iothealth/backend/controller/AlertControllerTest.java
@@ -1,4 +1,128 @@
 package com.iothealth.backend.controller;
 
-public class AlertControllerTest {
+import com.iothealth.backend.dto.alert.AlertResponse;
+import com.iothealth.backend.entity.AlertSeverity;
+import com.iothealth.backend.entity.AlertType;
+import com.iothealth.backend.exception.ResourceNotFoundException;
+import com.iothealth.backend.service.AlertService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(AlertController.class)
+class AlertControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private AlertService alertService;
+
+    private AlertResponse alertResponse;
+
+    @BeforeEach
+    void setUp() {
+        alertResponse = new AlertResponse(
+                1L, AlertType.HIGH_HEART_RATE, AlertSeverity.WARNING,
+                "Warning high heart rate detected: 115 bpm",
+                false, Instant.now(), null,
+                1L, "Sara El Amrani",
+                1L, "DEV-001", 1L
+        );
+    }
+
+    // --- GET /api/v1/alerts ---
+
+    @Test
+    void getAllAlerts_returns200WithList() throws Exception {
+        when(alertService.getAllAlerts()).thenReturn(List.of(alertResponse));
+
+        mockMvc.perform(get("/api/v1/alerts"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].type").value("HIGH_HEART_RATE"))
+                .andExpect(jsonPath("$[0].severity").value("WARNING"))
+                .andExpect(jsonPath("$[0].resolved").value(false));
+    }
+
+    @Test
+    void getAllAlerts_empty_returns200WithEmptyList() throws Exception {
+        when(alertService.getAllAlerts()).thenReturn(List.of());
+
+        mockMvc.perform(get("/api/v1/alerts"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(0));
+    }
+
+    // --- GET /api/v1/alerts/unresolved ---
+
+    @Test
+    void getUnresolvedAlerts_returns200WithList() throws Exception {
+        when(alertService.getUnresolvedAlerts()).thenReturn(List.of(alertResponse));
+
+        mockMvc.perform(get("/api/v1/alerts/unresolved"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].resolved").value(false));
+    }
+
+    // --- GET /api/v1/alerts/patient/{patientId} ---
+
+    @Test
+    void getAlertsByPatientId_returns200WithList() throws Exception {
+        when(alertService.getAlertsByPatientId(1L)).thenReturn(List.of(alertResponse));
+
+        mockMvc.perform(get("/api/v1/alerts/patient/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].patientId").value(1L));
+    }
+
+    @Test
+    void getAlertsByPatientId_noAlerts_returns200WithEmptyList() throws Exception {
+        when(alertService.getAlertsByPatientId(99L)).thenReturn(List.of());
+
+        mockMvc.perform(get("/api/v1/alerts/patient/99"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(0));
+    }
+
+    // --- PUT /api/v1/alerts/{id}/resolve ---
+
+    @Test
+    void resolveAlert_returns200WithResolvedAlert() throws Exception {
+        AlertResponse resolved = new AlertResponse(
+                1L, AlertType.HIGH_HEART_RATE, AlertSeverity.WARNING,
+                "Warning high heart rate detected: 115 bpm",
+                true, alertResponse.createdAt(), Instant.now(),
+                1L, "Sara El Amrani",
+                1L, "DEV-001", 1L
+        );
+
+        when(alertService.resolveAlert(1L)).thenReturn(resolved);
+
+        mockMvc.perform(put("/api/v1/alerts/1/resolve"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.resolved").value(true))
+                .andExpect(jsonPath("$.resolvedAt").isNotEmpty());
+    }
+
+    @Test
+    void resolveAlert_notFound_returns404() throws Exception {
+        when(alertService.resolveAlert(99L))
+                .thenThrow(new ResourceNotFoundException("Alert not found with id: 99"));
+
+        mockMvc.perform(put("/api/v1/alerts/99/resolve"))
+                .andExpect(status().isNotFound());
+    }
 }

--- a/backend/src/test/java/com/iothealth/backend/controller/AlertControllerTest.java
+++ b/backend/src/test/java/com/iothealth/backend/controller/AlertControllerTest.java
@@ -1,0 +1,4 @@
+package com.iothealth.backend.controller;
+
+public class AlertControllerTest {
+}

--- a/backend/src/test/java/com/iothealth/backend/controller/DeviceControllerTest.java
+++ b/backend/src/test/java/com/iothealth/backend/controller/DeviceControllerTest.java
@@ -1,0 +1,4 @@
+package com.iothealth.backend.controller;
+
+public class DeviceControllerTest {
+}

--- a/backend/src/test/java/com/iothealth/backend/controller/DeviceControllerTest.java
+++ b/backend/src/test/java/com/iothealth/backend/controller/DeviceControllerTest.java
@@ -1,4 +1,190 @@
 package com.iothealth.backend.controller;
 
-public class DeviceControllerTest {
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.iothealth.backend.dto.device.DeviceRequest;
+import com.iothealth.backend.dto.device.DeviceResponse;
+import com.iothealth.backend.entity.DeviceStatus;
+import com.iothealth.backend.exception.ResourceNotFoundException;
+import com.iothealth.backend.service.DeviceService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(DeviceController.class)
+class DeviceControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private DeviceService deviceService;
+
+    private DeviceResponse deviceResponse;
+    private DeviceRequest validRequest;
+
+    @BeforeEach
+    void setUp() {
+        deviceResponse = new DeviceResponse(
+                1L, "DEV-001", "Multi-parameter monitor",
+                DeviceStatus.ACTIVE, 1L, "Sara El Amrani",
+                Instant.now(), Instant.now()
+        );
+
+        validRequest = new DeviceRequest("DEV-001", "Multi-parameter monitor", DeviceStatus.ACTIVE, 1L);
+    }
+
+    // --- POST /api/v1/devices ---
+
+    @Test
+    void createDevice_validRequest_returns201() throws Exception {
+        when(deviceService.createDevice(any(DeviceRequest.class))).thenReturn(deviceResponse);
+
+        mockMvc.perform(post("/api/v1/devices")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(validRequest)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.deviceCode").value("DEV-001"))
+                .andExpect(jsonPath("$.status").value("ACTIVE"));
+    }
+
+    @Test
+    void createDevice_blankDeviceCode_returns400() throws Exception {
+        DeviceRequest invalid = new DeviceRequest("", "Monitor", DeviceStatus.ACTIVE, 1L);
+
+        mockMvc.perform(post("/api/v1/devices")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalid)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void createDevice_nullPatientId_returns400() throws Exception {
+        DeviceRequest invalid = new DeviceRequest("DEV-001", "Monitor", DeviceStatus.ACTIVE, null);
+
+        mockMvc.perform(post("/api/v1/devices")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalid)))
+                .andExpect(status().isBadRequest());
+    }
+
+    // --- GET /api/v1/devices ---
+
+    @Test
+    void getAllDevices_returns200WithList() throws Exception {
+        when(deviceService.getAllDevices()).thenReturn(List.of(deviceResponse));
+
+        mockMvc.perform(get("/api/v1/devices"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].deviceCode").value("DEV-001"));
+    }
+
+    // --- GET /api/v1/devices/{id} ---
+
+    @Test
+    void getDeviceById_found_returns200() throws Exception {
+        when(deviceService.getDeviceById(1L)).thenReturn(deviceResponse);
+
+        mockMvc.perform(get("/api/v1/devices/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(1L));
+    }
+
+    @Test
+    void getDeviceById_notFound_returns404() throws Exception {
+        when(deviceService.getDeviceById(99L))
+                .thenThrow(new ResourceNotFoundException("Device not found with id: 99"));
+
+        mockMvc.perform(get("/api/v1/devices/99"))
+                .andExpect(status().isNotFound());
+    }
+
+    // --- GET /api/v1/devices/code/{deviceCode} ---
+
+    @Test
+    void getDeviceByCode_found_returns200() throws Exception {
+        when(deviceService.getDeviceByCode("DEV-001")).thenReturn(deviceResponse);
+
+        mockMvc.perform(get("/api/v1/devices/code/DEV-001"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.deviceCode").value("DEV-001"));
+    }
+
+    @Test
+    void getDeviceByCode_notFound_returns404() throws Exception {
+        when(deviceService.getDeviceByCode("DEV-999"))
+                .thenThrow(new ResourceNotFoundException("Device not found with code: DEV-999"));
+
+        mockMvc.perform(get("/api/v1/devices/code/DEV-999"))
+                .andExpect(status().isNotFound());
+    }
+
+    // --- GET /api/v1/devices/patient/{patientId} ---
+
+    @Test
+    void getDeviceByPatientId_found_returns200() throws Exception {
+        when(deviceService.getDeviceByPatientId(1L)).thenReturn(deviceResponse);
+
+        mockMvc.perform(get("/api/v1/devices/patient/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.patientId").value(1L));
+    }
+
+    // --- PUT /api/v1/devices/{id} ---
+
+    @Test
+    void updateDevice_validRequest_returns200() throws Exception {
+        when(deviceService.updateDevice(eq(1L), any(DeviceRequest.class)))
+                .thenReturn(deviceResponse);
+
+        mockMvc.perform(put("/api/v1/devices/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(validRequest)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.deviceCode").value("DEV-001"));
+    }
+
+    @Test
+    void updateDevice_blankType_returns400() throws Exception {
+        DeviceRequest invalid = new DeviceRequest("DEV-001", "", DeviceStatus.ACTIVE, 1L);
+
+        mockMvc.perform(put("/api/v1/devices/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalid)))
+                .andExpect(status().isBadRequest());
+    }
+
+    // --- DELETE /api/v1/devices/{id} ---
+
+    @Test
+    void deleteDevice_returns204() throws Exception {
+        doNothing().when(deviceService).deleteDevice(1L);
+
+        mockMvc.perform(delete("/api/v1/devices/1"))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void deleteDevice_notFound_returns404() throws Exception {
+        doThrow(new ResourceNotFoundException("Device not found with id: 99"))
+                .when(deviceService).deleteDevice(99L);
+
+        mockMvc.perform(delete("/api/v1/devices/99"))
+                .andExpect(status().isNotFound());
+    }
 }

--- a/backend/src/test/java/com/iothealth/backend/controller/PatientControllerTest.java
+++ b/backend/src/test/java/com/iothealth/backend/controller/PatientControllerTest.java
@@ -1,0 +1,4 @@
+package com.iothealth.backend.controller;
+
+public class PatientControllerTest {
+}

--- a/backend/src/test/java/com/iothealth/backend/controller/PatientControllerTest.java
+++ b/backend/src/test/java/com/iothealth/backend/controller/PatientControllerTest.java
@@ -1,4 +1,180 @@
 package com.iothealth.backend.controller;
 
-public class PatientControllerTest {
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.iothealth.backend.dto.patient.PatientRequest;
+import com.iothealth.backend.dto.patient.PatientResponse;
+import com.iothealth.backend.entity.Gender;
+import com.iothealth.backend.exception.ResourceNotFoundException;
+import com.iothealth.backend.service.PatientService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(PatientController.class)
+class PatientControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private PatientService patientService;
+
+    private PatientResponse patientResponse;
+    private PatientRequest validRequest;
+
+    @BeforeEach
+    void setUp() {
+        patientResponse = new PatientResponse(
+                1L, "Sara", "El Amrani", 42, Gender.FEMALE,
+                "A-102", "Cardiac observation",
+                Instant.now(), Instant.now()
+        );
+
+        validRequest = new PatientRequest(
+                "Sara", "El Amrani", 42, Gender.FEMALE, "A-102", "Cardiac observation"
+        );
+    }
+
+    // --- POST /api/v1/patients ---
+
+    @Test
+    void createPatient_validRequest_returns201() throws Exception {
+        when(patientService.createPatient(any(PatientRequest.class))).thenReturn(patientResponse);
+
+        mockMvc.perform(post("/api/v1/patients")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(validRequest)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(1L))
+                .andExpect(jsonPath("$.firstName").value("Sara"))
+                .andExpect(jsonPath("$.roomNumber").value("A-102"));
+    }
+
+    @Test
+    void createPatient_blankFirstName_returns400() throws Exception {
+        PatientRequest invalid = new PatientRequest(
+                "", "El Amrani", 42, Gender.FEMALE, "A-102", null
+        );
+
+        mockMvc.perform(post("/api/v1/patients")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalid)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void createPatient_nullGender_returns400() throws Exception {
+        PatientRequest invalid = new PatientRequest(
+                "Sara", "El Amrani", 42, null, "A-102", null
+        );
+
+        mockMvc.perform(post("/api/v1/patients")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalid)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void createPatient_ageTooHigh_returns400() throws Exception {
+        PatientRequest invalid = new PatientRequest(
+                "Sara", "El Amrani", 150, Gender.FEMALE, "A-102", null
+        );
+
+        mockMvc.perform(post("/api/v1/patients")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalid)))
+                .andExpect(status().isBadRequest());
+    }
+
+    // --- GET /api/v1/patients ---
+
+    @Test
+    void getAllPatients_returns200WithList() throws Exception {
+        when(patientService.getAllPatients()).thenReturn(List.of(patientResponse));
+
+        mockMvc.perform(get("/api/v1/patients"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].lastName").value("El Amrani"));
+    }
+
+    // --- GET /api/v1/patients/{id} ---
+
+    @Test
+    void getPatientById_found_returns200() throws Exception {
+        when(patientService.getPatientById(1L)).thenReturn(patientResponse);
+
+        mockMvc.perform(get("/api/v1/patients/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(1L));
+    }
+
+    @Test
+    void getPatientById_notFound_returns404() throws Exception {
+        when(patientService.getPatientById(99L))
+                .thenThrow(new ResourceNotFoundException("Patient not found with id: 99"));
+
+        mockMvc.perform(get("/api/v1/patients/99"))
+                .andExpect(status().isNotFound());
+    }
+
+    // --- PUT /api/v1/patients/{id} ---
+
+    @Test
+    void updatePatient_validRequest_returns200() throws Exception {
+        when(patientService.updatePatient(eq(1L), any(PatientRequest.class)))
+                .thenReturn(patientResponse);
+
+        mockMvc.perform(put("/api/v1/patients/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(validRequest)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.firstName").value("Sara"));
+    }
+
+    @Test
+    void updatePatient_blankLastName_returns400() throws Exception {
+        PatientRequest invalid = new PatientRequest(
+                "Sara", "", 42, Gender.FEMALE, "A-102", null
+        );
+
+        mockMvc.perform(put("/api/v1/patients/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalid)))
+                .andExpect(status().isBadRequest());
+    }
+
+    // --- DELETE /api/v1/patients/{id} ---
+
+    @Test
+    void deletePatient_returns204() throws Exception {
+        doNothing().when(patientService).deletePatient(1L);
+
+        mockMvc.perform(delete("/api/v1/patients/1"))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void deletePatient_notFound_returns404() throws Exception {
+        doThrow(new ResourceNotFoundException("Patient not found with id: 99"))
+                .when(patientService).deletePatient(99L);
+
+        mockMvc.perform(delete("/api/v1/patients/99"))
+                .andExpect(status().isNotFound());
+    }
 }

--- a/backend/src/test/java/com/iothealth/backend/controller/VitalSignControllerTest.java
+++ b/backend/src/test/java/com/iothealth/backend/controller/VitalSignControllerTest.java
@@ -1,0 +1,4 @@
+package com.iothealth.backend.controller;
+
+public class VitalSignControllerTest {
+}

--- a/backend/src/test/java/com/iothealth/backend/controller/VitalSignControllerTest.java
+++ b/backend/src/test/java/com/iothealth/backend/controller/VitalSignControllerTest.java
@@ -1,4 +1,162 @@
 package com.iothealth.backend.controller;
 
-public class VitalSignControllerTest {
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.iothealth.backend.dto.vitalsign.VitalSignRequest;
+import com.iothealth.backend.dto.vitalsign.VitalSignResponse;
+import com.iothealth.backend.exception.ResourceNotFoundException;
+import com.iothealth.backend.service.VitalSignService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(VitalSignController.class)
+class VitalSignControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private VitalSignService vitalSignService;
+
+    private VitalSignResponse vitalSignResponse;
+    private VitalSignRequest validRequest;
+
+    @BeforeEach
+    void setUp() {
+        vitalSignResponse = new VitalSignResponse(
+                1L, 1L, "Sara El Amrani",
+                1L, "DEV-001",
+                75, BigDecimal.valueOf(36.8), 98,
+                Instant.now(), Instant.now()
+        );
+
+        validRequest = new VitalSignRequest(
+                "DEV-001", 75, BigDecimal.valueOf(36.8), 98, null
+        );
+    }
+
+    // --- POST /api/v1/vitals ---
+
+    @Test
+    void ingestVitalSign_validRequest_returns201() throws Exception {
+        when(vitalSignService.ingestVitalSign(any(VitalSignRequest.class)))
+                .thenReturn(vitalSignResponse);
+
+        mockMvc.perform(post("/api/v1/vitals")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(validRequest)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.heartRate").value(75))
+                .andExpect(jsonPath("$.spo2").value(98))
+                .andExpect(jsonPath("$.deviceCode").value("DEV-001"));
+    }
+
+    @Test
+    void ingestVitalSign_blankDeviceCode_returns400() throws Exception {
+        VitalSignRequest invalid = new VitalSignRequest(
+                "", 75, BigDecimal.valueOf(36.8), 98, null
+        );
+
+        mockMvc.perform(post("/api/v1/vitals")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalid)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void ingestVitalSign_heartRateTooLow_returns400() throws Exception {
+        VitalSignRequest invalid = new VitalSignRequest(
+                "DEV-001", 20, BigDecimal.valueOf(36.8), 98, null  // min is 30
+        );
+
+        mockMvc.perform(post("/api/v1/vitals")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalid)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void ingestVitalSign_temperatureOutOfRange_returns400() throws Exception {
+        VitalSignRequest invalid = new VitalSignRequest(
+                "DEV-001", 75, BigDecimal.valueOf(50.0), 98, null  // max is 45.0
+        );
+
+        mockMvc.perform(post("/api/v1/vitals")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalid)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void ingestVitalSign_spo2TooLow_returns400() throws Exception {
+        VitalSignRequest invalid = new VitalSignRequest(
+                "DEV-001", 75, BigDecimal.valueOf(36.8), 40, null  // min is 50
+        );
+
+        mockMvc.perform(post("/api/v1/vitals")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalid)))
+                .andExpect(status().isBadRequest());
+    }
+
+    // --- GET /api/v1/vitals/patient/{patientId}/latest ---
+
+    @Test
+    void getLatestVitalSign_found_returns200() throws Exception {
+        when(vitalSignService.getLatestVitalSignByPatientId(1L))
+                .thenReturn(vitalSignResponse);
+
+        mockMvc.perform(get("/api/v1/vitals/patient/1/latest"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.patientId").value(1L))
+                .andExpect(jsonPath("$.heartRate").value(75));
+    }
+
+    @Test
+    void getLatestVitalSign_notFound_returns404() throws Exception {
+        when(vitalSignService.getLatestVitalSignByPatientId(99L))
+                .thenThrow(new ResourceNotFoundException("No vital sign readings found for patient id: 99"));
+
+        mockMvc.perform(get("/api/v1/vitals/patient/99/latest"))
+                .andExpect(status().isNotFound());
+    }
+
+    // --- GET /api/v1/vitals/patient/{patientId}/history ---
+
+    @Test
+    void getVitalSignHistory_returns200WithList() throws Exception {
+        when(vitalSignService.getVitalSignHistoryByPatientId(eq(1L), isNull(), isNull(), eq(100)))
+                .thenReturn(List.of(vitalSignResponse));
+
+        mockMvc.perform(get("/api/v1/vitals/patient/1/history"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].deviceCode").value("DEV-001"));
+    }
+
+    @Test
+    void getVitalSignHistory_withLimit_returns200() throws Exception {
+        when(vitalSignService.getVitalSignHistoryByPatientId(eq(1L), isNull(), isNull(), eq(10)))
+                .thenReturn(List.of(vitalSignResponse));
+
+        mockMvc.perform(get("/api/v1/vitals/patient/1/history")
+                        .param("limit", "10"))
+                .andExpect(status().isOk());
+    }
 }


### PR DESCRIPTION
## Summary
Adds `@WebMvcTest` slice tests for all four REST controllers using MockMvc and mocked service dependencies. No real database or full Spring context is loaded.

## Related Issue
Closes #55

## Changes
- Added `PatientControllerTest`: create (valid, blank name, null gender, age out of range), get all, get by id (found/404), update (valid/invalid), delete (success/404)
- Added `DeviceControllerTest`: create (valid, blank code, null patientId), get all, get by id/code/patientId (found/404), update (valid/invalid), delete (success/404)
- Added `VitalSignControllerTest`: ingest (valid, blank code, HR/temp/SpO2 out of range), latest (found/404), history (default and with limit param)
- Added `AlertControllerTest`: get all (list/empty), get unresolved, get by patient, resolve (success/404)

## Testing
- [ ] Backend runs successfully
- [ ] Frontend runs successfully
- [ ] API tested with Postman/Swagger
- [ ] No breaking changes

## Checklist
- [ ] Code builds
- [ ] No direct commit to main
- [ ] Documentation updated if needed

## Summary by Sourcery

Add controller-layer slice tests for REST endpoints using MockMvc with mocked services.

Tests:
- Add WebMvcTest-based coverage for PatientController create, retrieval, update, delete, and validation error paths.
- Add WebMvcTest-based coverage for DeviceController CRUD operations and validation error scenarios.
- Add WebMvcTest-based coverage for VitalSignController ingestion, latest reading, and history endpoints including validation and parameter handling.
- Add WebMvcTest-based coverage for AlertController listing, filtering, and resolve flows, including empty and not-found cases.