### PR TITLE
feat: add optional MQTT ingestion path (Mosquitto + Eclipse Paho)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,178 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+IoT Health Monitoring Platform — a full-stack system that simulates connected medical devices sending real-time vital signs (heart rate, temperature, SpO2) to a Spring Boot backend. Abnormal readings trigger alerts that are pushed live to a React frontend via STOMP/WebSocket. No physical hardware required; a Python simulator drives the entire data flow.
+
+## Architecture
+
+```
+Python Simulator ──HTTP POST──► Spring Boot (8080) ◄──REST + WS──► React Frontend (5173)
+Python MQTT pub  ──MQTT pub──►  Mosquitto (1883)                        │
+                                        │  ◄──MQTT sub──────────────────┘ (optional)
+                                   PostgreSQL (5432)
+```
+
+**Services:**
+- `backend/` — Java 17, Spring Boot 3.5, Spring Data JPA, Spring WebSocket (STOMP over SockJS)
+- `frontend/` — React 19, Vite, React Router, Axios, @stomp/stompjs
+- `simulator/` — Python 3.12 script that generates realistic vital drift with configurable anomaly injection
+- `mosquitto/` — optional Mosquitto broker config for MQTT ingestion (see `docker-compose.mqtt.yml`)
+
+**WebSocket topics published by the backend:**
+- `/topic/vitals` — all incoming vital sign readings
+- `/topic/patients/{id}/vitals` — patient-scoped vitals
+- `/topic/alerts` — all new alerts
+- `/topic/patients/{id}/alerts` — patient-scoped alerts
+
+## Commands
+
+### Backend (Java/Maven)
+```powershell
+cd backend
+.\mvnw.cmd spring-boot:run          # start API on :8080
+.\mvnw.cmd test                     # run all unit tests
+.\mvnw.cmd test -Dtest=AlertServiceTest   # run a single test class
+.\mvnw.cmd package -DskipTests      # build jar
+```
+
+### Frontend (Node/Vite)
+```powershell
+cd frontend
+npm install
+npm run dev        # dev server on :5173
+npm run build      # production build
+npm run lint       # ESLint
+npm run preview    # preview production build
+```
+
+### Simulator (Python)
+```powershell
+cd simulator
+python -m venv venv
+.\venv\Scripts\Activate.ps1
+pip install -r requirements.txt
+cp .env.example .env               # then edit device codes / API URL
+python simulator.py
+```
+
+### MQTT (optional)
+```powershell
+# Start Mosquitto broker via Docker
+docker-compose -f docker-compose.mqtt.yml up -d
+
+# Publish one batch of test readings
+cd simulator && python mqtt_publisher.py
+
+# Publish continuously with anomalies
+python mqtt_publisher.py --loop --anomaly
+```
+
+## Configuration
+
+### Backend
+Copy `backend/src/main/resources/application.example.yml` → `application.yml`:
+```yaml
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:5432/iot_health_db
+    username: postgres
+    password: YOUR_PASSWORD
+app:
+  cors.allowed-origins: http://localhost:5173
+  websocket.allowed-origins: http://localhost:5173
+```
+Hibernate manages schema automatically (`ddl-auto: update`).
+
+### Frontend
+Copy `frontend/.env.example` → `.env.local`:
+```
+VITE_API_BASE_URL=http://localhost:8080/api/v1
+VITE_WS_URL=http://localhost:8080/ws
+```
+
+### Simulator
+Edit `simulator/.env`:
+```
+API_BASE_URL=http://localhost:8080/api/v1
+DEVICE_CODES=DEV-001,DEV-002       # must exist in DB
+INTERVAL_SECONDS=5
+ANOMALY_RATE=0.10                  # 0.0–1.0
+# MQTT publisher also reads these, plus:
+MQTT_BROKER_HOST=localhost
+MQTT_BROKER_PORT=1883
+```
+
+### MQTT (backend)
+Add to `application.yml` to enable:
+```yaml
+app:
+  mqtt:
+    enabled: true
+    broker-url: tcp://localhost:1883
+    client-id: iot-health-backend
+    topic-pattern: iot-health/devices/+/vitals
+    qos: 1
+```
+When `enabled: false` (the default), nothing MQTT-related starts and no broker is needed.
+
+## Key Packages / Patterns
+
+### Backend (`backend/src/main/java/com/iothealth/backend/`)
+- **`controller/`** → thin REST layer, delegates to services
+- **`service/`** → business logic; `VitalSignService` ingests readings, calls `AlertService`, then fires WebSocket events
+- **`entity/`** → JPA entities; `VitalSign`, `Alert` (with 5 composite indices), `Device`, `Patient`; all relationships are `FetchType.LAZY`
+- **`websocket/`** → `VitalSignWebSocketPublisher`, `AlertWebSocketPublisher` — called from services, not controllers
+- **`dto/` + `mapper/`** → separate request/response shapes from entities
+
+Alert thresholds (in `AlertService`):
+
+| Vital | Warning | Critical |
+|-------|---------|----------|
+| Heart rate | ≥ 110 bpm | < 50 or > 120 bpm |
+| Temperature | ≥ 37.8 °C | < 35.0 or > 38.0 °C |
+| SpO2 | ≤ 94% | ≤ 92% |
+
+### Frontend (`frontend/src/`)
+- **`api/`** — Axios instance (`httpClient.js`) + domain clients; STOMP factory (`wsClient.js`)
+- **`hooks/`** — custom hooks combine initial fetch with WebSocket subscription; e.g. `usePatients()` fetches the patient list then keeps vitals live via `/topic/vitals`
+- **`pages/`** — `DashboardPage`, `PatientDetailPage`, `AlertCenterPage`
+
+### Simulator (`simulator/simulator.py`)
+Each device tracks independent vital state that drifts toward a normal range. At each tick there is an `ANOMALY_RATE` chance of injecting one of 8 pre-defined anomaly scenarios (e.g., `high_hr_critical`, `spo2_warning`). Validates all device codes against the API on startup and skips any that don't exist.
+
+### MQTT ingestion (`backend/src/main/java/com/iothealth/backend/mqtt/`)
+Four classes implement the optional second ingestion path:
+- `MqttProperties` — `@ConfigurationProperties(prefix = "app.mqtt")` record
+- `MqttConfig` — `@ConditionalOnProperty(enabled=true)` activates the whole subsystem
+- `MqttPayload` — JSON deserialization record for incoming MQTT messages
+- `MqttVitalSignListener` — `MqttCallback` that connects on `@PostConstruct`, subscribes to `topicPattern`, parses each message into a `VitalSignRequest`, and calls `VitalSignService.ingestVitalSign()` — identical to the HTTP path
+
+Topic convention: `iot-health/devices/{deviceCode}/vitals` (`+` wildcard in subscription).
+
+## REST API Base Path
+
+All REST endpoints are under `/api/v1`. Swagger UI: `http://localhost:8080/swagger-ui/index.html`
+
+Key endpoints:
+- `POST /vitals` — ingest a vital sign reading (used by simulator)
+- `GET /vitals/patient/{id}/history?from=&to=&limit=` — paginated history (max 500)
+- `PUT /alerts/{id}/resolve` — mark alert resolved
+- `GET /devices/code/{code}` — look up device by its string code
+
+## Database Setup
+
+```sql
+CREATE DATABASE iot_health_db;
+```
+
+Hibernate auto-creates all tables on first run.
+
+## Docs
+
+- `docs/setup-guide.md` — step-by-step local setup and troubleshooting
+- `docs/websocket-topics.md` — WebSocket subscription reference
+- `docs/demo-scenario.md` — presentation walkthrough script
+- `docs/mqtt-guide.md` — MQTT broker setup, publisher usage, payload reference

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -76,6 +76,13 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+
+		<!-- MQTT support (Eclipse Paho) -->
+		<dependency>
+			<groupId>org.eclipse.paho</groupId>
+			<artifactId>org.eclipse.paho.client.mqttv3</artifactId>
+			<version>1.2.5</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/backend/src/main/java/com/iothealth/backend/mqtt/MqttConfig.java
+++ b/backend/src/main/java/com/iothealth/backend/mqtt/MqttConfig.java
@@ -1,0 +1,11 @@
+package com.iothealth.backend.mqtt;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConditionalOnProperty(name = "app.mqtt.enabled", havingValue = "true")
+@EnableConfigurationProperties(MqttProperties.class)
+public class MqttConfig {
+}

--- a/backend/src/main/java/com/iothealth/backend/mqtt/MqttPayload.java
+++ b/backend/src/main/java/com/iothealth/backend/mqtt/MqttPayload.java
@@ -1,0 +1,16 @@
+package com.iothealth.backend.mqtt;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record MqttPayload(
+        String deviceCode,
+        Integer heartRate,
+        BigDecimal temperature,
+        Integer spo2,
+        Instant recordedAt
+) {
+}

--- a/backend/src/main/java/com/iothealth/backend/mqtt/MqttProperties.java
+++ b/backend/src/main/java/com/iothealth/backend/mqtt/MqttProperties.java
@@ -1,0 +1,24 @@
+package com.iothealth.backend.mqtt;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.bind.DefaultValue;
+
+@ConfigurationProperties(prefix = "app.mqtt")
+public record MqttProperties(
+
+        @DefaultValue("false")
+        boolean enabled,
+
+        @DefaultValue("tcp://localhost:1883")
+        String brokerUrl,
+
+        @DefaultValue("iot-health-backend")
+        String clientId,
+
+        @DefaultValue("iot-health/devices/+/vitals")
+        String topicPattern,
+
+        @DefaultValue("1")
+        int qos
+) {
+}

--- a/backend/src/main/java/com/iothealth/backend/mqtt/MqttVitalSignListener.java
+++ b/backend/src/main/java/com/iothealth/backend/mqtt/MqttVitalSignListener.java
@@ -1,0 +1,94 @@
+package com.iothealth.backend.mqtt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.iothealth.backend.dto.vitalsign.VitalSignRequest;
+import com.iothealth.backend.service.VitalSignService;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.paho.client.mqttv3.IMqttDeliveryToken;
+import org.eclipse.paho.client.mqttv3.MqttCallback;
+import org.eclipse.paho.client.mqttv3.MqttClient;
+import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
+import org.eclipse.paho.client.mqttv3.MqttException;
+import org.eclipse.paho.client.mqttv3.MqttMessage;
+import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "app.mqtt.enabled", havingValue = "true")
+public class MqttVitalSignListener implements MqttCallback {
+
+    private final VitalSignService vitalSignService;
+    private final ObjectMapper objectMapper;
+    private final MqttProperties mqttProperties;
+
+    private MqttClient mqttClient;
+
+    @PostConstruct
+    public void connect() throws MqttException {
+        mqttClient = new MqttClient(
+                mqttProperties.brokerUrl(),
+                mqttProperties.clientId(),
+                new MemoryPersistence()
+        );
+
+        MqttConnectOptions options = new MqttConnectOptions();
+        options.setCleanSession(true);
+        options.setAutomaticReconnect(true);
+
+        mqttClient.setCallback(this);
+        mqttClient.connect(options);
+        mqttClient.subscribe(mqttProperties.topicPattern(), mqttProperties.qos());
+
+        log.info("MQTT listener connected to {} — subscribed to '{}'",
+                mqttProperties.brokerUrl(), mqttProperties.topicPattern());
+    }
+
+    @PreDestroy
+    public void disconnect() {
+        if (mqttClient != null && mqttClient.isConnected()) {
+            try {
+                mqttClient.disconnect();
+                log.info("MQTT listener disconnected");
+            } catch (MqttException e) {
+                log.warn("Error while disconnecting MQTT client: {}", e.getMessage());
+            }
+        }
+    }
+
+    @Override
+    public void messageArrived(String topic, MqttMessage message) {
+        String payload = new String(message.getPayload());
+        log.debug("MQTT message received on topic '{}': {}", topic, payload);
+
+        try {
+            MqttPayload mqttPayload = objectMapper.readValue(payload, MqttPayload.class);
+            VitalSignRequest request = new VitalSignRequest(
+                    mqttPayload.deviceCode(),
+                    mqttPayload.heartRate(),
+                    mqttPayload.temperature(),
+                    mqttPayload.spo2(),
+                    mqttPayload.recordedAt()
+            );
+            vitalSignService.ingestVitalSign(request);
+            log.debug("MQTT vital sign ingested for device '{}'", mqttPayload.deviceCode());
+        } catch (Exception e) {
+            log.error("Failed to process MQTT message on topic '{}': {}", topic, e.getMessage());
+        }
+    }
+
+    @Override
+    public void connectionLost(Throwable cause) {
+        log.warn("MQTT connection lost: {} — automatic reconnect is enabled", cause.getMessage());
+    }
+
+    @Override
+    public void deliveryComplete(IMqttDeliveryToken token) {
+        // not used — this listener only subscribes, never publishes
+    }
+}

--- a/backend/src/main/resources/application.example.yml
+++ b/backend/src/main/resources/application.example.yml
@@ -29,3 +29,9 @@ app:
     allowed-origins: http://localhost:5173,http://localhost:3000
   websocket:
     allowed-origins: http://localhost:5173,http://localhost:3000
+  mqtt:
+    enabled: false                          # set to true to enable MQTT ingestion
+    broker-url: tcp://localhost:1883        # Mosquitto broker URL
+    client-id: iot-health-backend           # unique client ID for this service
+    topic-pattern: iot-health/devices/+/vitals  # + matches any single device code
+    qos: 1                                  # 0=at-most-once, 1=at-least-once, 2=exactly-once

--- a/docker-compose.mqtt.yml
+++ b/docker-compose.mqtt.yml
@@ -1,0 +1,9 @@
+services:
+  mosquitto:
+    image: eclipse-mosquitto:2
+    container_name: iot-health-mosquitto
+    ports:
+      - "1883:1883"
+    volumes:
+      - ./mosquitto/mosquitto.conf:/mosquitto/config/mosquitto.conf
+    restart: unless-stopped

--- a/docs/mqtt-guide.md
+++ b/docs/mqtt-guide.md
@@ -1,0 +1,180 @@
+# MQTT Ingestion Guide
+
+MQTT is an **optional, additive** ingestion path. The existing HTTP `POST /api/v1/vitals` endpoint is unchanged. When MQTT is enabled the backend subscribes to:
+
+```
+iot-health/devices/{deviceCode}/vitals
+```
+
+Any message arriving on that topic is processed by the same pipeline as an HTTP request: vital sign saved → alert detection → WebSocket broadcast → visible in the frontend.
+
+---
+
+## Prerequisites
+
+- Docker Desktop (to run Mosquitto), **or** Mosquitto installed natively
+- Backend already running with a valid `application.yml`
+- `paho-mqtt` installed in the simulator venv (already in `requirements.txt`)
+
+---
+
+## 1. Start the Mosquitto Broker
+
+### Option A — Docker (recommended)
+
+```powershell
+docker-compose -f docker-compose.mqtt.yml up -d
+```
+
+Mosquitto starts on `localhost:1883`. To stop it:
+
+```powershell
+docker-compose -f docker-compose.mqtt.yml down
+```
+
+### Option B — Native Mosquitto
+
+Install from [mosquitto.org/download](https://mosquitto.org/download/), then run with the provided config:
+
+```powershell
+mosquitto -c mosquitto/mosquitto.conf
+```
+
+---
+
+## 2. Enable MQTT in the Backend
+
+In `backend/src/main/resources/application.yml`, set:
+
+```yaml
+app:
+  mqtt:
+    enabled: true
+    broker-url: tcp://localhost:1883
+    client-id: iot-health-backend
+    topic-pattern: iot-health/devices/+/vitals
+    qos: 1
+```
+
+The `+` wildcard matches any single device code segment, so one subscription covers all devices.
+
+Restart the backend. On startup you should see:
+
+```
+MQTT listener connected to tcp://localhost:1883 — subscribed to 'iot-health/devices/+/vitals'
+```
+
+---
+
+## 3. Publish Test Messages
+
+### Option A — Python publisher
+
+```powershell
+cd simulator
+# activate your venv first, then:
+python mqtt_publisher.py                # one round of normal readings, then exit
+python mqtt_publisher.py --loop         # continuous publishing (every INTERVAL_SECONDS)
+python mqtt_publisher.py --anomaly      # inject an anomalous reading in the first batch
+python mqtt_publisher.py --loop --anomaly
+```
+
+The publisher reads `DEVICE_CODES` and `INTERVAL_SECONDS` from the same `.env` used by the HTTP simulator. Add `MQTT_BROKER_HOST` and `MQTT_BROKER_PORT` to `.env` if the broker is not on localhost:
+
+```env
+MQTT_BROKER_HOST=localhost
+MQTT_BROKER_PORT=1883
+```
+
+### Option B — Mosquitto CLI (`mosquitto_pub`)
+
+Publish a single reading for DEV-001:
+
+```bash
+mosquitto_pub -h localhost -p 1883 \
+  -t "iot-health/devices/DEV-001/vitals" \
+  -m '{"deviceCode":"DEV-001","heartRate":88,"temperature":36.9,"spo2":97,"recordedAt":"2026-05-05T10:00:00Z"}'
+```
+
+Trigger a critical SpO2 alert:
+
+```bash
+mosquitto_pub -h localhost -p 1883 \
+  -t "iot-health/devices/DEV-001/vitals" \
+  -m '{"deviceCode":"DEV-001","heartRate":80,"temperature":36.8,"spo2":91,"recordedAt":"2026-05-05T10:00:01Z"}'
+```
+
+---
+
+## 4. Verify End-to-End
+
+1. Open the frontend at `http://localhost:5173`.
+2. Publish a message via the Python publisher or `mosquitto_pub`.
+3. The patient card for the device's patient should update in real time — the same as when the HTTP simulator sends data.
+4. If the reading crosses an alert threshold, an alert badge appears immediately.
+
+You can also confirm via the REST API:
+
+```powershell
+# Replace 1 with the actual patient ID
+Invoke-RestMethod http://localhost:8080/api/v1/vitals/patient/1/latest
+```
+
+---
+
+## MQTT Payload Format
+
+```json
+{
+  "deviceCode": "DEV-001",
+  "heartRate": 88,
+  "temperature": 36.9,
+  "spo2": 97,
+  "recordedAt": "2026-05-05T10:00:00Z"
+}
+```
+
+| Field         | Type            | Constraints                  |
+|---------------|-----------------|------------------------------|
+| `deviceCode`  | string          | must exist in the database   |
+| `heartRate`   | integer         | 30–220 bpm                   |
+| `temperature` | decimal         | 30.0–45.0 °C                 |
+| `spo2`        | integer         | 50–100 %                     |
+| `recordedAt`  | ISO-8601 string | optional — defaults to now   |
+
+---
+
+## Topic Convention
+
+```
+iot-health/devices/{deviceCode}/vitals
+```
+
+Examples:
+
+```
+iot-health/devices/DEV-001/vitals
+iot-health/devices/DEV-002/vitals
+```
+
+The backend subscribes to `iot-health/devices/+/vitals`. The `+` is an MQTT single-level wildcard that matches exactly one path segment, so all device topics are covered by a single subscription.
+
+---
+
+## Configuration Reference
+
+All properties live under `app.mqtt` in `application.yml`:
+
+| Property        | Default                            | Description                              |
+|-----------------|------------------------------------|------------------------------------------|
+| `enabled`       | `false`                            | Set to `true` to activate MQTT ingestion |
+| `broker-url`    | `tcp://localhost:1883`             | Paho broker URL                          |
+| `client-id`     | `iot-health-backend`               | MQTT client identifier                   |
+| `topic-pattern` | `iot-health/devices/+/vitals`      | Topic to subscribe to                    |
+| `qos`           | `1`                                | QoS level (0, 1, or 2)                   |
+
+---
+
+## Future: Wokwi ESP32 Simulation
+
+Once the MQTT pipeline is stable locally, a [Wokwi](https://wokwi.com/) ESP32 sketch can replace or complement the Python publisher. The ESP32 connects to the same Mosquitto broker and publishes to the same topic convention. No backend changes are needed — the broker URL just needs to be reachable from the Wokwi simulation network.

--- a/mosquitto/mosquitto.conf
+++ b/mosquitto/mosquitto.conf
@@ -1,0 +1,3 @@
+# Mosquitto broker config for local development
+listener 1883
+allow_anonymous true

--- a/simulator/mqtt_publisher.py
+++ b/simulator/mqtt_publisher.py
@@ -1,0 +1,111 @@
+"""
+MQTT test publisher for the IoT Health Monitoring Platform.
+
+Publishes sample vital sign payloads to:
+  iot-health/devices/{deviceCode}/vitals
+
+The backend MQTT listener (when enabled) picks these up and runs them
+through the same ingestion pipeline as the HTTP simulator.
+
+Usage:
+  python mqtt_publisher.py              # publish one round of readings and exit
+  python mqtt_publisher.py --loop       # publish continuously (same interval as .env)
+  python mqtt_publisher.py --anomaly    # include an anomalous reading in the first batch
+"""
+
+import argparse
+import json
+import os
+import random
+import sys
+import time
+from datetime import datetime, timezone
+
+import paho.mqtt.client as mqtt
+from dotenv import load_dotenv
+
+load_dotenv()
+
+BROKER_HOST = os.getenv("MQTT_BROKER_HOST", "localhost")
+BROKER_PORT = int(os.getenv("MQTT_BROKER_PORT", "1883"))
+DEVICE_CODES = [c.strip() for c in os.getenv("DEVICE_CODES", "DEV-001").split(",") if c.strip()]
+INTERVAL_SECONDS = int(os.getenv("INTERVAL_SECONDS", "5"))
+TOPIC_PREFIX = "iot-health/devices"
+
+
+def normal_reading(device_code: str) -> dict:
+    return {
+        "deviceCode": device_code,
+        "heartRate": random.randint(65, 95),
+        "temperature": round(random.uniform(36.2, 37.4), 1),
+        "spo2": random.randint(96, 99),
+        "recordedAt": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+    }
+
+
+def anomalous_reading(device_code: str) -> dict:
+    scenarios = [
+        {"heartRate": 125, "temperature": 38.5, "spo2": 97},   # high HR + fever
+        {"heartRate": 45,  "temperature": 36.5, "spo2": 97},   # low HR critical
+        {"heartRate": 80,  "temperature": 36.8, "spo2": 91},   # low SpO2 critical
+        {"heartRate": 112, "temperature": 37.9, "spo2": 94},   # high HR + temp warning
+    ]
+    overrides = random.choice(scenarios)
+    reading = normal_reading(device_code)
+    reading.update(overrides)
+    return reading
+
+
+def publish_readings(client: mqtt.Client, use_anomaly: bool = False) -> None:
+    for device_code in DEVICE_CODES:
+        reading = anomalous_reading(device_code) if use_anomaly else normal_reading(device_code)
+        topic = f"{TOPIC_PREFIX}/{device_code}/vitals"
+        payload = json.dumps(reading)
+        result = client.publish(topic, payload, qos=1)
+        result.wait_for_publish()
+        print(f"  [{device_code}] -> {topic}")
+        print(f"           {payload}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="MQTT vital sign test publisher")
+    parser.add_argument("--loop", action="store_true", help="publish continuously")
+    parser.add_argument("--anomaly", action="store_true", help="inject anomalous readings")
+    args = parser.parse_args()
+
+    client = mqtt.Client(client_id="iot-health-mqtt-publisher", clean_session=True)
+
+    print(f"Connecting to MQTT broker at {BROKER_HOST}:{BROKER_PORT} ...")
+    try:
+        client.connect(BROKER_HOST, BROKER_PORT, keepalive=60)
+    except Exception as e:
+        print(f"ERROR: Could not connect to broker: {e}")
+        print("Make sure Mosquitto is running (see docs/mqtt-guide.md).")
+        sys.exit(1)
+
+    client.loop_start()
+
+    print(f"Publishing to topic prefix: {TOPIC_PREFIX}/{{deviceCode}}/vitals")
+    print(f"Devices: {', '.join(DEVICE_CODES)}")
+    print()
+
+    try:
+        if args.loop:
+            print(f"Loop mode — publishing every {INTERVAL_SECONDS}s. Press Ctrl+C to stop.\n")
+            first = True
+            while True:
+                publish_readings(client, use_anomaly=args.anomaly and first)
+                first = False
+                time.sleep(INTERVAL_SECONDS)
+        else:
+            publish_readings(client, use_anomaly=args.anomaly)
+            print("\nDone.")
+    except KeyboardInterrupt:
+        print("\nStopped.")
+    finally:
+        client.loop_stop()
+        client.disconnect()
+
+
+if __name__ == "__main__":
+    main()

--- a/simulator/requirements.txt
+++ b/simulator/requirements.txt
@@ -1,2 +1,3 @@
 requests==2.32.3
 python-dotenv==1.0.1
+paho-mqtt>=1.6.1,<2.0


### PR DESCRIPTION
## Summary

Adds MQTT as an optional, additive second ingestion channel. The existing
POST /api/v1/vitals HTTP endpoint is completely unchanged. When
app.mqtt.enabled: true is set in application.yml, the backend subscribes to
iot-health/devices/+/vitals and routes every message through the exact same
pipeline as HTTP: persist vital sign → detect alerts → broadcast via
WebSocket → frontend updates live.

## Changes

- backend/ — Eclipse Paho v3 dependency + new mqtt/ package:
  - MqttProperties — typed @ConfigurationProperties(prefix="app.mqtt") record
  - MqttConfig — @ConditionalOnProperty(enabled=true) so nothing MQTT-related
    starts unless explicitly opted in
  - MqttPayload — JSON deserialization record
  - MqttVitalSignListener — MqttCallback that connects on @PostConstruct,
    subscribes to topic pattern, calls VitalSignService.ingestVitalSign()
- application.example.yml — app.mqtt.* section (enabled: false default)
- docker-compose.mqtt.yml + mosquitto/mosquitto.conf — local Mosquitto broker
- simulator/mqtt_publisher.py — Python test publisher (--loop, --anomaly flags)
- simulator/requirements.txt — paho-mqtt>=1.6.1,<2.0
- docs/mqtt-guide.md — full setup and usage guide
- CLAUDE.md — initial codebase guide, updated with MQTT section

## Testing

- [x] Backend runs with app.mqtt.enabled: false (default, no broker needed)
- [x] Backend runs with app.mqtt.enabled: true (with Mosquitto running)
- [x] HTTP ingestion unaffected
- [x] MQTT messages trigger same pipeline (save → alerts → WebSocket broadcast)
- [x] No breaking changes

## Checklist

- [x] Code builds
- [x] No direct commit to main
- [x] Documentation updated

## Summary by Sourcery

Add an optional MQTT-based ingestion path alongside existing HTTP vitals ingestion, wired into the same backend processing pipeline and supported by local Mosquitto infrastructure and simulator tooling.

New Features:
- Introduce MQTT-based vital sign ingestion via a Spring Boot listener that subscribes to configured topics and forwards messages into the existing VitalSignService pipeline.
- Add a Python MQTT simulator script to publish test vital readings to the backend via Mosquitto.

Enhancements:
- Document MQTT setup and usage, including broker configuration, payload format, and verification steps in a dedicated guide.
- Provide a repository guidance document (CLAUDE.md) describing project architecture, key components, and MQTT integration.
- Extend backend configuration to support MQTT properties with sensible defaults and conditional activation.

Build:
- Add Eclipse Paho MQTT client dependency to the backend Maven configuration.

Documentation:
- Add an MQTT ingestion guide covering broker setup, configuration, topic conventions, and payload reference.